### PR TITLE
Update configuration files

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,5 +3,14 @@
     [
       "@babel/env", {"modules": false}
     ]
-  ]
+  ],
+  "env" : {
+    "test" : {
+      "presets": [
+        [
+          "@babel/env"
+        ]
+      ]
+    }
+  }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -4,8 +4,10 @@
     "ecmaVersion": 2018,
     "sourceType": "module"
   },
+  "ignorePatterns": ["dist", "docs", "node_modules", "dev/*.esm*"],
   "env": {
-    "browser": true
+    "browser": true,
+    "jest": true
   },
   "rules": {
     "require-jsdoc": "error",

--- a/__TESTS__/unit/actions/Resize.test.js
+++ b/__TESTS__/unit/actions/Resize.test.js
@@ -1,3 +1,5 @@
+import Resize from 'actions/resize';
+
 describe('Test', () => {
   it('works', () => {
     expect(true).toBe(true);

--- a/jest.config.json
+++ b/jest.config.json
@@ -3,6 +3,9 @@
   "collectCoverageFrom": [
     "src/**/*.js"
   ],
+  "modulePaths": [
+    "<rootDir>/src"
+  ],
   "coverageThreshold": {
     "global": {
       "branches": 95,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1623,6 +1623,16 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/jest": {
+      "version": "25.2.1",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-25.2.1.tgz",
+      "integrity": "sha512-msra1bCaAeEdkSyA0CZ6gW1ukMIvZ5YoJkdXw/qhQdsuuDlFTcEUrUw8CLCPt2rVRUfXlClVvK2gvPs9IokZaA==",
+      "dev": true,
+      "requires": {
+        "jest-diff": "^25.2.1",
+        "pretty-format": "^25.2.1"
+      }
+    },
     "@types/node": {
       "version": "13.9.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.8.tgz",

--- a/package.json
+++ b/package.json
@@ -6,12 +6,13 @@
   "scripts": {
     "test": "jest --coverage",
     "test:unit": "jest __TESTS__/unit",
-    "test:unit:watch" : "jest __TESTS__/unit --watch",
+    "test:unit:watch": "jest __TESTS__/unit --watch",
     "test:integration": "jest __TESTS__/integration",
     "test:integration:watch": "jest __TESTS__/integration --watch",
-    "build": "eslint src --color && npm run build:types && rollup -c && npm run build:docs",
+    "build": "npm run lint && npm run build:types && rollup -c && npm run build:docs",
     "build:docs": "jsdoc --configure jsdoc.config.json --verbose",
     "build:types": "tsc",
+    "lint": "eslint src __TESTS__ --color",
     "start": "rollup -c rollup.dev.config.js -w",
     "bundlewatch": "bundlewatch --config ./bundlewatch.config.js"
   },
@@ -23,6 +24,7 @@
     "@babel/core": "^7.9.0",
     "@babel/preset-env": "^7.9.0",
     "@rollup/plugin-node-resolve": "^7.1.1",
+    "@types/jest": "^25.2.1",
     "bundlewatch": "^0.2.6",
     "eslint": "^6.8.0",
     "foodoc": "0.0.9",


### PR DESCRIPTION
- Update jest to allow imports from src without full path (src as root)
- Update eslint to support jest
- Update build script to also lint  __TESTS__
- Install @types/jest for IDE support
- Update babelrc, include test env to allow babel to transform modules for Jest