### PR TITLE
Add sideEffects key in package.json for webpack tree shaking

### DIFF
--- a/__TESTS__/unit/scripts/createEntryPoints.test.ts
+++ b/__TESTS__/unit/scripts/createEntryPoints.test.ts
@@ -19,6 +19,7 @@ describe('Tests for createEntryPoints', () => {
 
     expect(entryPointPackageJSON.types).toBe('../../types/actions/border/Border.d.ts');
     expect(entryPointPackageJSON.main).toBe('../../bundles/esm/actions/border/Border.js');
+    expect(entryPointPackageJSON.sideEffects).toBe(false);
   });
 
   it ('Works on extremely nested inputs', () => {
@@ -27,6 +28,7 @@ describe('Tests for createEntryPoints', () => {
 
     expect(entryPointPackageJSON.types).toBe('../../../../../../types/deep/nested/entryPoint1/EntryPoint1.d.ts');
     expect(entryPointPackageJSON.main).toBe('../../../../../../bundles/esm/deep/nested/entryPoint1/EntryPoint1.js');
+    expect(entryPointPackageJSON.sideEffects).toBe(false);
   });
 
   it ('Creates the main entrypoint to the project', () => {
@@ -37,6 +39,7 @@ describe('Tests for createEntryPoints', () => {
     expect(mainPackageJson.main).toBe('./bundles/esm/index.js');
     // Expect not to delete existing values
     expect(mainPackageJson.fieldA).toBe('foobar');
+    expect(mainPackageJson.sideEffects).toBe(false);
   });
 
   it ('Creates a UMD Bundle Entrypoint', () => {
@@ -47,6 +50,7 @@ describe('Tests for createEntryPoints', () => {
     expect(umdBundlePackageJson.main).toBe('./base.js');
     // Expect not to delete existing values
     expect(umdBundlePackageJson.types).toBe('../../types/index.d.ts');
+    expect(umdBundlePackageJson.sideEffects).toBe(false);
   });
 
   it('Fails if it cannot find a d.ts file', () => {

--- a/scripts/lib/entryPointsLib.ts
+++ b/scripts/lib/entryPointsLib.ts
@@ -1,6 +1,10 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const fs = require('fs');
 
+const commonPackageProperties = {
+  sideEffects:false
+};
+
 /**
  * @description Utlity - Capitalize the first character of a string
  * @param str
@@ -70,10 +74,16 @@ function createEntryPointFromESMPath(pathInESMBundle: string, entryPointInDist: 
         throw `\n***\nBUILD ERROR - Invalid folder structure detected \n\n${msg} \n***\n`;
       }
 
-      fs.writeFileSync(`${FULL_ENTRY_POINT_PATH}/${name}/package.json`, JSON.stringify({
+
+      const packageJson = Object.assign({
         "types": `${rootPathToDist}/types/${pathInESMBundle}/${name}/${capitalize(name)}.d.ts`,
         "main": `${rootPathToDist}/bundles/esm/${pathInESMBundle}/${name}/${capitalize(name)}.js`
-      }, null, '\t'));
+      }, commonPackageProperties);
+
+      fs.writeFileSync(
+        `${FULL_ENTRY_POINT_PATH}/${name}/package.json`,
+        JSON.stringify(packageJson,null, '\t')
+      );
     }
   });
 }
@@ -84,11 +94,16 @@ function createEntryPointFromESMPath(pathInESMBundle: string, entryPointInDist: 
  * Allows users to import from '@base/bundles/umd'
  */
 function createUMDBundleEntryPoint() {
-  // create umd
-  fs.writeFileSync(`dist/bundles/umd/package.json`, JSON.stringify({
+  const packageJson = Object.assign({
     "types": `../../types/index.d.ts`,
     "main": `./base.js`
-  }, null, '\t'));
+  }, commonPackageProperties);
+
+  // create umd
+  fs.writeFileSync(
+    `dist/bundles/umd/package.json`,
+    JSON.stringify(packageJson, null, '\t')
+  );
 }
 
 
@@ -101,6 +116,8 @@ function createMainEntryPoint() {
   delete projectJson.scripts;
   delete projectJson.devDependencies;
   projectJson.main = './bundles/esm/index.js';
+
+  Object.assign(projectJson, commonPackageProperties);
   fs.writeFileSync('./dist/package.json', JSON.stringify(projectJson, null, '\t'));
 }
 


### PR DESCRIPTION
This PR adds in all our package.json files the "sideEffects:false" key which allows webpack to properly tree shake the ES module files.