### PR TITLE
Enable usage of an instance with a shared configuration

### DIFF
--- a/__TESTS__/unit/Instance/Cloudinary.test.ts
+++ b/__TESTS__/unit/Instance/Cloudinary.test.ts
@@ -1,0 +1,20 @@
+import TransformableImage from "../../../src/transformation/TransformableImage";
+import CloudinaryConfig from "../../../src/config/CloudinaryConfig";
+import Cloudinary from "../../../src/instance/Cloudinary";
+import fill from "../../../src/actions/resize/fill";
+
+describe('Tests for Cloudinary instance', () => {
+  it ('Creates an instance with its own global config', () => {
+    const cloudinary = new Cloudinary(new CloudinaryConfig({
+      cloud: {
+        cloudName:'demoInInstance'
+      }
+    }));
+    cloudinary.useImage(TransformableImage);
+    const tImage = cloudinary.image('sample');
+
+    tImage.resize(fill(10, 10));
+
+    expect(tImage.toURL()).toBe('http://res.cloudinary.com/demoInInstance/image/upload/c_fill,w_10,h_10/sample');
+  });
+});

--- a/src/instance/Cloudinary.ts
+++ b/src/instance/Cloudinary.ts
@@ -1,0 +1,36 @@
+import TransformableImage from "../transformation/TransformableImage";
+import ICloudinaryConfigurations from "../interfaces/Config/ICloudinaryConfigurations";
+
+class Cloudinary {
+  TransformableImage: typeof TransformableImage;
+  cloudinaryConfig: ICloudinaryConfigurations;
+
+  constructor(cloudinaryConfig?: ICloudinaryConfigurations) {
+    if (cloudinaryConfig) {
+      this.cloudinaryConfig = cloudinaryConfig;
+    }
+  }
+
+  useImage(TImage: typeof TransformableImage) {
+    this.TransformableImage = TImage;
+  }
+
+  image(publicID: string) {
+    if (!this.TransformableImage) {
+      throw 'You cannot use image without first invoking useImage()';
+    }
+    return new this.TransformableImage(publicID).setConfig(this.cloudinaryConfig);
+  }
+
+  setConfig(cloudinaryConfig: ICloudinaryConfigurations) {
+    this.cloudinaryConfig = cloudinaryConfig;
+  }
+
+  extendConfig(cloudinaryConfig: ICloudinaryConfigurations) {
+    // Future implementation
+  }
+}
+
+
+
+export default Cloudinary;


### PR DESCRIPTION
Notes,
The idea here is to allow users to re-use their configurations without passing them again and again, but also preventing them from accidentally importing all our code at once.

Developers can create an empty Cloudinary instance, and through code `inject` the classes they want to use.

This will allow us in the future to `inject` future plugins without having anything directly in the instance.