### PR TITLE
Add action - Named transformation

### DIFF
--- a/__TESTS__/unit/actions/NamedTransformation.test.ts
+++ b/__TESTS__/unit/actions/NamedTransformation.test.ts
@@ -1,0 +1,49 @@
+import TransformableImage from '../../../src/transformation/TransformableImage';
+import CloudinaryConfig from "../../../src/config/CloudinaryConfig";
+import NamedTransformation, {name} from "../../../src/actions/namedTransformation/NamedTransformation";
+import Resize, {scale} from "../../../src/actions/resize/Resize";
+
+const CONFIG_INSTANCE = new CloudinaryConfig({
+  cloud: {
+    cloudName: 'demo'
+  }
+});
+
+describe('Tests for Transformation Action -- NamedTransformation', () => {
+  it('Ensures NamedTransformation is accepted as an action to TransformableImage', () => {
+    const tImage = new TransformableImage();
+    // Ensures it compiles and doesn't throw
+    expect(
+      tImage.namedTransformation(NamedTransformation.name('foobar'))
+    ).toEqual(tImage);
+  });
+
+  it('Ensures name is accepted as an action to TransformableImage', () => {
+    const tImage = new TransformableImage();
+    // Ensures it compiles and doesn't throw
+    expect(
+      tImage.namedTransformation(name('foobar'))
+    ).toEqual(tImage);
+  });
+
+  it('Creates a cloudinaryURL with name', () => {
+    const url = new TransformableImage()
+      .setConfig(CONFIG_INSTANCE)
+      .namedTransformation(name('foobar'))
+      .setPublicID('sample')
+      .toURL();
+
+    expect(url).toBe('http://res.cloudinary.com/demo/image/upload/t_foobar/sample');
+  });
+
+  it('Creates a cloudinaryURL with name and resize', () => {
+    const url = new TransformableImage()
+      .setConfig(CONFIG_INSTANCE)
+      .resize(scale(100, 100))
+      .namedTransformation(name('foobar'))
+      .setPublicID('sample')
+      .toURL();
+
+    expect(url).toBe('http://res.cloudinary.com/demo/image/upload/c_scale,w_100,h_100/t_foobar/sample');
+  });
+});

--- a/src/actions/namedTransformation/INamedTransformationAction.ts
+++ b/src/actions/namedTransformation/INamedTransformationAction.ts
@@ -1,0 +1,4 @@
+import {IAction} from "../../interfaces/IAction";
+
+export interface INamedTransformationAction extends IAction {
+}

--- a/src/actions/namedTransformation/NamedTransformation.ts
+++ b/src/actions/namedTransformation/NamedTransformation.ts
@@ -1,0 +1,21 @@
+import Action from "../Action";
+import Param from "../../parameters/Param";
+import {INamedTransformationAction} from "./INamedTransformationAction";
+
+class NamedTransformationAction extends Action implements INamedTransformationAction{
+  constructor(name:string) {
+    super();
+    this.addParam(new Param('t', name));
+  }
+}
+
+/**
+ *
+ */
+function name(name:string): NamedTransformationAction {
+  return new NamedTransformationAction(name);
+}
+
+
+export {name};
+export default {name};

--- a/src/transformation/TransformableImage.ts
+++ b/src/transformation/TransformableImage.ts
@@ -11,6 +11,7 @@ import {IQualityAction} from "../actions/quality/IQualityAction";
 import {IRotateAction} from "../actions/rotate/IRotateAction";
 import {IVariableAction} from "../actions/variable/IVariableAction";
 import {ILayerAction} from "../actions/layers/ILayerAction";
+import {INamedTransformationAction} from "../actions/namedTransformation/INamedTransformationAction";
 
 /**
  * @augments Transformation
@@ -107,6 +108,13 @@ class TransformableImage extends Transformation {
    */
   rotate(rotateAction: IRotateAction): TransformableImage {
     return this.addAction(rotateAction);
+  }
+
+  /**
+   * @param {INamedTransformationAction} namedTransformation
+   */
+  namedTransformation(namedTransformation:INamedTransformationAction ) {
+    return this.addAction(namedTransformation);
   }
 
   /**


### PR DESCRIPTION
Notes:

Implemented differently from PHP/Kotlin, since we can't have direct operations on the transformation.

Syntax was changed from
`image.namedTransformation('foo')`

to
`image.namedTransformation(name('foo'))`

As always feel free to suggest better names 