### PR TITLE
Enable passing env variable to code generator

### DIFF
--- a/scripts/updateCompliationTests.js
+++ b/scripts/updateCompliationTests.js
@@ -19,6 +19,8 @@ const ENV_RUBY_VER = process.argv[4] || process.env.ENV_RUBY_VER || '2.7.1';
 const { execSync } = require('child_process');
 const fs = require('fs');
 
+// Enable passing a key to the code generator.
+// This enables us to create compiation tests based on a specific qualifier (like `a_` or `c_`)
 const addKeyEnvVar = process.env.KEY ? `KEY=${process.env.KEY}` : ''
 const bashScript = ` 
   cd ${CODE_GENERATOR_PATH};


### PR DESCRIPTION
### Pull reuqest for @Cloudianry/Base


#### What does this PR solve?
This PR adds the ability to pass a key to the code generator, allowing the creation of very refined compilation tests
Examples:
* Create a file with all tests containing `a_`
* Create a file with all tests containing `g_`

Example usage:
`KEY=g npm run test:comp`

Additionally, Added general UI improvements to the `updateCompilationsTest.ts` file


#### Final checklist (All N/A)
- [ ] JSdoc - Add proper docstrings based on our PHP implementation
- [ ] JSdoc - Hide private functions using @private
- [ ] Implementation is aligned with PHP Reference(If different, please specify why)
- [ ] Tests - Add proper tests to the added code
