### PR TITLE
Implement text-layer for overlays

### DIFF
--- a/__TESTS__/unit/actions/Overlay.text.test.ts
+++ b/__TESTS__/unit/actions/Overlay.text.test.ts
@@ -1,0 +1,94 @@
+import {Source, textLayer} from "../../../src/actions/layers/Layers";
+import TransformableImage from "../../../src/transformation/TransformableImage";
+import {Position, center} from "../../../src/params/position/Position";
+import CloudinaryConfig from "../../../src/config/CloudinaryConfig";
+import {TextSource} from "../../../src/actions/layers/Source";
+import {BlendMode} from "../../../src/params/blendMode/BlendMode";
+import {FontStyle, FontWeight} from "../../../src/params/fonts/Fonts";
+
+const CONFIG_INSTANCE = new CloudinaryConfig({
+  cloud: {
+    cloudName: 'demo'
+  }
+});
+
+/**
+ * @private
+ * @param source
+ * @param position
+ * @param blendMode
+ */
+function getImageWithOverlay(source: TextSource, position?: Position, blendMode?: BlendMode) {
+  return new TransformableImage('sample')
+    .setConfig(CONFIG_INSTANCE)
+    .overlay(
+      textLayer(source, position, blendMode)
+    );
+}
+
+describe('Tests for overlay texts', () => {
+  it('Adds an Text Overlay', () => {
+    const url = getImageWithOverlay(Source.text('Testing')).toURL();
+    expect(url).toContain('l_text:Testing/fl_layer_apply/sample');
+  });
+
+  it('Adds a Text Overlay with font family', () => {
+    const url = getImageWithOverlay(
+      Source.text('Testing')
+        .fontFamily('arial')
+    ).toURL();
+    expect(url).toContain('l_text:arial:Testing/fl_layer_apply/sample');
+  });
+
+  it('Adds a Text Overlay with font family and size', () => {
+    const url = getImageWithOverlay(
+      Source.text('Testing')
+        .fontFamily('arial')
+        .fontSize(20)
+    ).toURL();
+    expect(url).toContain('l_text:arial_20:Testing/fl_layer_apply/sample');
+  });
+
+  it('Adds a Text Overlay with font family and size and weight', () => {
+    const url = getImageWithOverlay(
+      Source.text('Testing')
+        .fontFamily('arial')
+        .fontSize(20)
+        .fontWeight(FontWeight.BOLD)
+    ).toURL();
+    expect(url).toContain('l_text:arial_20_bold:Testing/fl_layer_apply/sample');
+  });
+
+  it('Adds a Text Overlay with font family and size and weight and color', () => {
+    const url = getImageWithOverlay(
+      Source.text('Testing')
+        .fontFamily('arial')
+        .fontSize(20)
+        .fontWeight('bold')
+        .color('red')
+    ).toURL();
+    expect(url).toContain('l_text:arial_20_bold:Testing,co_red/fl_layer_apply/sample');
+  });
+
+  it('Adds a Text Overlay with font family and size and weight and color', () => {
+    const url = getImageWithOverlay(
+      Source.text('Testing')
+        .fontFamily('arial')
+        .fontSize(20)
+        .fontWeight('bold')
+        .fontStyle(FontStyle.ITALIC)
+        .color('red')
+    ).toURL();
+    expect(url).toContain('l_text:arial_20_bold_italic:Testing,co_red/fl_layer_apply/sample');
+  });
+
+  it('Adds an Text Overlay with position', () => {
+    const url = getImageWithOverlay(
+      Source.text('Testing'),
+      center()
+        .x(50)
+        .y(100)
+    ).toURL();
+    expect(url).toContain('l_text:Testing/fl_layer_apply,g_center,x_50,y_100/sample');
+  });
+});

--- a/src/actions/layers/ISource.ts
+++ b/src/actions/layers/ISource.ts
@@ -1,0 +1,7 @@
+/**
+ * @private
+ */
+export interface ISource {
+  getSource():string,
+  getTransformationString():void
+}

--- a/src/actions/layers/Layers.ts
+++ b/src/actions/layers/Layers.ts
@@ -8,17 +8,18 @@
 import {ILayerAction} from "./ILayerAction";
 import Action from "../Action";
 // TODO - BundleSize Warning - we include all the Sources code within Layers.
-import Source, {ImageSource} from "./Source";
+import Source, {ImageSource, TextSource} from "./Source";
 import {Position} from "../../params/position/Position";
 import Param from "../../parameters/Param";
 import {BlendMode} from "../../params/blendMode/BlendMode";
+import {ISource} from "./ISource";
 
 
 class Layer extends Action implements ILayerAction {
-  source: ImageSource; // TODO this needs to accept other types of sources
+  source: ISource;
   position:Position;
   blendMode: BlendMode;
-  constructor(transformable: ImageSource, position:Position, blendMode: BlendMode) {
+  constructor(transformable: ISource, position:Position, blendMode: BlendMode) {
     super();
     this.source = transformable;
     this.position = position;
@@ -30,7 +31,7 @@ class Layer extends Action implements ILayerAction {
    * The opening of a layer
    */
   openLayer() {
-    return `l_${this.source.asset.publicID}`;
+    return `l_${this.source.getSource()}`;
   }
 
   /**
@@ -38,7 +39,7 @@ class Layer extends Action implements ILayerAction {
    * Transformations conducted on the image in the layer
    */
   layerTransformation() {
-    return this.source.toString();
+    return this.source.getTransformationString();
   }
 
   /**
@@ -73,11 +74,19 @@ class Layer extends Action implements ILayerAction {
  * @return {Layer}
  */
 function imageLayer(imageSource: ImageSource, position?:Position, blendMode?:BlendMode): Layer {
-  // TODO this needs to accept other types of sources
   return new Layer(imageSource, position, blendMode);
 }
 
+/**
+ * @param textSource
+ * @param position
+ * @param blendMode
+ * @memberOf Actions.Layers
+ * @return {Layer}
+ */
+function textLayer(textSource: TextSource, position?:Position, blendMode?:BlendMode): Layer {
+  return new Layer(textSource, position, blendMode);
+}
 
-export {imageLayer, Source};
-export default {imageLayer, Source};
-
+export {imageLayer, textLayer, Source};
+export default {imageLayer, textLayer, Source};

--- a/src/actions/layers/Source.ts
+++ b/src/actions/layers/Source.ts
@@ -1,8 +1,6 @@
-import TransformableImage from "../../transformation/TransformableImage";
+import TextSource from "./sources/TextSource";
+import ImageSource from "./sources/ImageSource";
 
-class ImageSource extends TransformableImage {
-
-}
 
 /**
  * @memberOf Sources
@@ -12,5 +10,14 @@ function image(publicID: string): ImageSource {
   return new ImageSource(publicID);
 }
 
-export default {ImageSource, image};
-export {ImageSource, image};
+
+/**
+ * @memberOf Sources
+ * @param someText {string}
+ */
+function text(someText: string): TextSource {
+  return new TextSource(someText);
+}
+
+export default {ImageSource, TextSource, image, text};
+export {ImageSource, TextSource, image, text};

--- a/src/actions/layers/sources/ImageSource.ts
+++ b/src/actions/layers/sources/ImageSource.ts
@@ -1,0 +1,17 @@
+import {ISource} from "../ISource";
+import TransformableImage from "../../../transformation/TransformableImage";
+
+/**
+ * @private
+ */
+class ImageSource extends TransformableImage implements ISource {
+  getSource():string {
+    return this.asset.publicID;
+  }
+
+  getTransformationString():string {
+    return this.toString();
+  }
+}
+
+export default ImageSource;

--- a/src/actions/layers/sources/TextSource.ts
+++ b/src/actions/layers/sources/TextSource.ts
@@ -1,0 +1,74 @@
+import {ISource} from "../ISource";
+import {FontStyle, FontWeight} from "../../../params/fonts/Fonts";
+import {prepareColor} from "../../../utils/prepareColor";
+import ParamValue from "../../../parameters/ParamValue";
+
+/**
+ * @private
+ */
+class TextSource implements ISource {
+  private fFamily: string;
+  private fSize: number;
+  private fWeight: string;
+  private textColor: string;
+  private innerText: string;
+  private fStyle: string;
+  constructor(someText:string) {
+    this.innerText = someText;
+  }
+
+  fontFamily(fontFam:string):this {
+    this.fFamily = fontFam;
+    return this;
+  }
+
+  fontSize(size:number):this {
+    this.fSize = size;
+    return this;
+  }
+
+  fontWeight(weight: keyof typeof FontWeight):this {
+    this.fWeight = weight;
+    return this;
+  }
+
+  fontStyle(style:keyof typeof FontStyle):this {
+    this.fStyle = style;
+    return this;
+  }
+
+  color(textColor: string):this {
+    this.textColor = textColor;
+    return this;
+  }
+
+  getColor():string {
+    if (this.textColor) {
+      return `co_${prepareColor(this.textColor)}`;
+    } else {
+      return '';
+    }
+  }
+
+  getSource():string {
+    const fontValue = new ParamValue([this.fFamily, this.fSize, this.fWeight, this.fStyle])
+      .setDelimiter('_')
+      .toString();
+
+    const fontAndText = new ParamValue(['text', fontValue, this.innerText])
+      .setDelimiter(':')
+      .toString();
+
+    const final = new ParamValue([fontAndText, this.getColor()])
+      .setDelimiter(',')
+      .toString();
+    return `${final}`;
+  }
+
+  getTransformationString():string {
+    return '';
+  }
+}
+
+
+export default TextSource;

--- a/src/params/fonts/Fonts.ts
+++ b/src/params/fonts/Fonts.ts
@@ -1,0 +1,21 @@
+export const FontStyle:Record<string, string> = {
+  NORMAL: 'normal',
+  ITALIC: 'italic'
+};
+
+
+export const FontWeight:Record<string, string> = {
+  THIN: 'thin',
+  EXTRA_LIGHT: 'extralight',
+  LIGHT: 'light',
+  NORMAL: 'normal',
+  BOOK: 'book',
+  MEDIUM: 'medium',
+  DEMIBOLD: 'demibold',
+  SEMIBOLD: 'semibold',
+  BOLD: 'bold',
+  EXTRABOLD: 'extrabold',
+  ULTRABOLD: 'ultrabold',
+  BLACK: 'black',
+  HEAVY: 'heavy'
+};


### PR DESCRIPTION
### Pull reuqest for @Cloudianry/Base


#### What does this PR solve?
This PR adds support for text overlays.

What was done:
* Created an interface for all sources 
* Method on ISource will now resolve the correct source string (for example `l_sample` vs `l_text:arial_20` 
* Moved the location of the ImageSource to a `/sources` directory under `/Source`

What we should consider moving forward:
* Source should probably be a `Param` (like Position and BlendMode)
* We're still missing docstrings here because it's not clear what we'll end up exporting, Once we have Video Source implemented we'll have the complete picture of what's private and what's public, and we can include the missing docstrings. I've opened internal issues to keep track of these missing docstrings.


#### Final checklist
- [ ] JSdoc - Add proper docstrings based on our PHP implementation
- [x] JSdoc - Hide private functions using @private
- [x] Implementation is aligned with PHP Reference(If different, please specify why)
- [x] Tests - Add proper tests to the added code
