### PR TITLE
Ensure file exists before deleteing - compilations.test.ts

### DIFF
--- a/scripts/updateCompliationTests.js
+++ b/scripts/updateCompliationTests.js
@@ -42,7 +42,9 @@ if (!fs.existsSync(TEST_FILE_PATH)) {
 const file = fs.readFileSync(TEST_FILE_PATH, 'utf-8');
 
 // Delete existing file
-fs.unlinkSync(COMPILATION_TESTS_LOCAL_PATH);
+if (fs.existsSync(COMPILATION_TESTS_LOCAL_PATH)) {
+  fs.unlinkSync(COMPILATION_TESTS_LOCAL_PATH);
+}
 
 // Create new file
 fs.writeFileSync(COMPILATION_TESTS_LOCAL_PATH, file);


### PR DESCRIPTION
### Pull reuqest for @Cloudianry/Base


#### What does this PR solve?
Fix a broken `npm run build:comp` command when the `compliation.test.ts` file does not exist yet on the file system

