### PR TITLE
Refactor tests to use the ensureESMDefault package

### DIFF
--- a/__TESTS__/unit/actions/Adjust.test.ts
+++ b/__TESTS__/unit/actions/Adjust.test.ts
@@ -1,6 +1,8 @@
 import CloudinaryConfig from "../../../src/config/CloudinaryConfig";
-import {Adjust} from "../../../src/actions/Actions";
+import Adjust from '../../../src/actions/adjust/Adjust';
+import * as AdjustESM from '../../../src/actions/adjust/Adjust';
 import {TransformableImage} from "../../../src";
+import expectESMToMatchDefault from "../../TestUtils/expectESMToMatchDefault";
 
 const {opacity, viesusCorrect, brightness, sharpen, improve, red, saturation, tint} = Adjust;
 
@@ -11,6 +13,10 @@ const CONFIG_INSTANCE = new CloudinaryConfig({
 });
 
 describe('Tests for Transformation Action -- Adjust', () => {
+  it('Expects ESM to match Default', () => {
+    expectESMToMatchDefault(AdjustESM, Adjust);
+  });
+
   it('Ensure namespace is correctly populated', () => {
     expect(Adjust.viesusCorrect).toEqual(viesusCorrect);
     expect(Adjust.opacity).toEqual(opacity);

--- a/__TESTS__/unit/actions/Border.test.ts
+++ b/__TESTS__/unit/actions/Border.test.ts
@@ -1,7 +1,11 @@
-import Border, {solid} from '../../../src/actions/border/Border';
+import Border from '../../../src/actions/border/Border';
+import * as BorderESM from '../../../src/actions/border/Border';
 import TransformableImage from '../../../src/transformation/TransformableImage';
 import CloudinaryConfig from "../../../src/config/CloudinaryConfig";
 import * as Colors from "../../../src/constants/colors/Colors";
+import expectESMToMatchDefault from "../../TestUtils/expectESMToMatchDefault";
+
+const {solid} = Border;
 
 const CONFIG_INSTANCE = new CloudinaryConfig({
   cloud: {
@@ -10,8 +14,8 @@ const CONFIG_INSTANCE = new CloudinaryConfig({
 });
 
 describe('Tests for Transformation Action -- Border', () => {
-  it('Ensures "solid" is exported in the Border namespace', () => {
-    expect(Border.solid).toEqual(solid);
+  it('Expects ESM to match Default', () => {
+    expectESMToMatchDefault(BorderESM, Border);
   });
 
   it('Is accepted as an action to TransformableImage', () => {

--- a/__TESTS__/unit/actions/Condition.test.ts
+++ b/__TESTS__/unit/actions/Condition.test.ts
@@ -1,8 +1,10 @@
-import Condition, {fromString} from '../../../src/actions/condition/Condition';
 import CloudinaryConfig from "../../../src/config/CloudinaryConfig";
 import TransformableImage from "../../../src/transformation/TransformableImage";
 import {variable} from "../../../src/actions/variable/Variable";
 import Resize from "../../../src/actions/resize/Resize";
+import expectESMToMatchDefault from "../../TestUtils/expectESMToMatchDefault";
+import * as ConditionESM from "../../../src/actions/condition/Condition";
+import Condition from "../../../src/actions/condition/Condition";
 
 const CONFIG_INSTANCE = new CloudinaryConfig({
   cloud: {
@@ -11,6 +13,10 @@ const CONFIG_INSTANCE = new CloudinaryConfig({
 });
 
 describe('Tests for Transformation Action -- Condition', () => {
+  it('Expects ESM to match Default', () => {
+    expectESMToMatchDefault(ConditionESM, Condition);
+  });
+
   it('Ensures Condition namespace is accepted as an action to TransformableImage', () => {
     const tImage = new TransformableImage();
     // Ensures it compiles and doesn't throw

--- a/__TESTS__/unit/actions/Delivery.test.ts
+++ b/__TESTS__/unit/actions/Delivery.test.ts
@@ -1,4 +1,3 @@
-import Delivery, {format} from '../../../src/actions/delivery/Delivery';
 import TransformableImage from '..         /../../src/transformation/TransformableImage';
 import CloudinaryConfig from "../../../src/config/CloudinaryConfig";
 import {
@@ -22,6 +21,9 @@ import {
   WEBM,
   WEBP
 } from "../../../src/params/formats/Formats";
+import expectESMToMatchDefault from "../../TestUtils/expectESMToMatchDefault";
+import * as DeliveryESM from "../../../src/actions/delivery/Delivery";
+import Delivery from "../../../src/actions/delivery/Delivery";
 
 const CONFIG_INSTANCE = new CloudinaryConfig({
   cloud: {
@@ -29,7 +31,13 @@ const CONFIG_INSTANCE = new CloudinaryConfig({
   }
 });
 
+const {format} = Delivery;
+
 describe('Tests for Transformation Action -- Delivery', () => {
+  it('Expects ESM to match Default', () => {
+    expectESMToMatchDefault(DeliveryESM, Delivery);
+  });
+
   it('Ensure namespace is correctly populated', () => {
     expect(Delivery.format).toEqual(format);
   });

--- a/__TESTS__/unit/actions/Effect.test.ts
+++ b/__TESTS__/unit/actions/Effect.test.ts
@@ -1,8 +1,11 @@
-import Effect, {blur, blurFaces, pixelateFaces, grayscale, sepia, shadow} from '../../../src/actions/effect/Effect';
 import TransformableImage from '../../../src/transformation/TransformableImage';
 import CloudinaryConfig from "../../../src/config/CloudinaryConfig";
 import * as ArtisticFilter from "../../../src/constants/artisticFilters/ArtisticFilters";
+import expectESMToMatchDefault from "../../TestUtils/expectESMToMatchDefault";
+import * as EffectESM from "../../../src/actions/effect/Effect";
+import Effect from "../../../src/actions/effect/Effect";
 
+const {blur, blurFaces, pixelateFaces, grayscale, sepia, shadow} = Effect;
 
 const CONFIG_INSTANCE = new CloudinaryConfig({
   cloud: {
@@ -11,13 +14,8 @@ const CONFIG_INSTANCE = new CloudinaryConfig({
 });
 
 describe('Tests for Transformation Action -- Effect', () => {
-  it('Ensure namespace is correctly populated', () => {
-    expect(Effect.blur).toEqual(blur);
-    expect(Effect.blurFaces).toEqual(blurFaces);
-    expect(Effect.pixelateFaces).toEqual(pixelateFaces);
-    expect(Effect.grayscale).toEqual(grayscale);
-    expect(Effect.sepia).toEqual(sepia);
-    expect(Effect.shadow).toEqual(shadow);
+  it('Expects ESM to match Default', () => {
+    expectESMToMatchDefault(EffectESM, Effect);
   });
 
   it('Ensures blur is accepted as an action to TransformableImage', () => {

--- a/__TESTS__/unit/actions/NamedTransformation.test.ts
+++ b/__TESTS__/unit/actions/NamedTransformation.test.ts
@@ -1,7 +1,9 @@
 import TransformableImage from '../../../src/transformation/TransformableImage';
 import CloudinaryConfig from "../../../src/config/CloudinaryConfig";
 import NamedTransformation, {name} from "../../../src/actions/namedTransformation/NamedTransformation";
-import Resize, {scale} from "../../../src/actions/resize/Resize";
+import * as NamedTransformationESM from "../../../src/actions/namedTransformation/NamedTransformation";
+import {scale} from "../../../src/actions/resize/Resize";
+import expectESMToMatchDefault from "../../TestUtils/expectESMToMatchDefault";
 
 const CONFIG_INSTANCE = new CloudinaryConfig({
   cloud: {
@@ -10,6 +12,10 @@ const CONFIG_INSTANCE = new CloudinaryConfig({
 });
 
 describe('Tests for Transformation Action -- NamedTransformation', () => {
+  it('Expects ESM to match Default', () => {
+    expectESMToMatchDefault(NamedTransformationESM, NamedTransformation);
+  });
+
   it('Ensures NamedTransformation is accepted as an action to TransformableImage', () => {
     const tImage = new TransformableImage();
     // Ensures it compiles and doesn't throw

--- a/__TESTS__/unit/actions/Overlay.test.ts
+++ b/__TESTS__/unit/actions/Overlay.test.ts
@@ -1,11 +1,20 @@
-import {fill} from "../../../src/actions/resize/Resize";
-import {imageLayer, Source} from "../../../src/actions/layers/Layers";
-import TransformableImage from "../../../src/transformation/TransformableImage";
-import * as Position from "../../../src/params/position/Position";
 import CloudinaryConfig from "../../../src/config/CloudinaryConfig";
-import BlendMode from "../../../src/params/blendMode/BlendMode";
-const {image} = Source;
+import TransformableImage from "../../../src/transformation/TransformableImage";
 
+import {fill} from "../../../src/actions/resize/Resize";
+
+import Layers from "../../../src/actions/layers/Layers";
+import * as LayersESM from "../../../src/actions/layers/Layers";
+
+import Position from "../../../src/params/position/Position";
+import BlendMode from "../../../src/params/blendMode/BlendMode";
+import * as PositionESM from "../../../src/params/position/Position";
+import * as BlendModeESM from "../../../src/params/blendMode/BlendMode";
+
+import expectESMToMatchDefault from "../../TestUtils/expectESMToMatchDefault";
+
+const {imageLayer} = Layers;
+const {image} = Layers.Source;
 
 const CONFIG_INSTANCE = new CloudinaryConfig({
   cloud: {
@@ -14,6 +23,12 @@ const CONFIG_INSTANCE = new CloudinaryConfig({
 });
 
 describe('Tests for overlay actions', () => {
+  it('Expects ESM to match Default', () => {
+    expectESMToMatchDefault(PositionESM, Position);
+    expectESMToMatchDefault(BlendModeESM, BlendMode);
+    expectESMToMatchDefault(LayersESM, Layers);
+  });
+
   it('Parses an overlay with an imageSource', () => {
     const tImage = new TransformableImage('sample');
     tImage

--- a/__TESTS__/unit/actions/Quality.test.ts
+++ b/__TESTS__/unit/actions/Quality.test.ts
@@ -1,7 +1,10 @@
-import Quality, {auto, level, jpegMini, best, eco, good, low} from '../../../src/actions/quality/Quality';
+import Quality from '../../../src/actions/quality/Quality';
+import * as QualityESM from '../../../src/actions/quality/Quality';
 import TransformableImage from '../../../src/transformation/TransformableImage';
 import CloudinaryConfig from "../../../src/config/CloudinaryConfig";
+import expectESMToMatchDefault from "../../TestUtils/expectESMToMatchDefault";
 
+const {auto, level, jpegMini, best, eco, good, low} = Quality;
 const CONFIG_INSTANCE = new CloudinaryConfig({
   cloud: {
     cloudName: 'demo'
@@ -9,14 +12,8 @@ const CONFIG_INSTANCE = new CloudinaryConfig({
 });
 
 describe('Tests for Transformation Action -- Quality', () => {
-  it('Ensure namespace is correctly populated', () => {
-    expect(Quality.auto).toEqual(auto);
-    expect(Quality.level).toEqual(level);
-    expect(Quality.jpegMini).toEqual(jpegMini);
-    expect(Quality.best).toEqual(best);
-    expect(Quality.eco).toEqual(eco);
-    expect(Quality.good).toEqual(good);
-    expect(Quality.low).toEqual(low);
+  it('Expects ESM to match Default', () => {
+    expectESMToMatchDefault(QualityESM, Quality);
   });
 
   it('Ensures auto is accepted as an action to TransformableImage', () => {

--- a/__TESTS__/unit/actions/Resize.test.ts
+++ b/__TESTS__/unit/actions/Resize.test.ts
@@ -5,6 +5,7 @@ import {AutoGravity} from "../../../src/constants/gravityObjects/GravityObjects"
 import Gravity from "../../../src/params/gravity/Gravity";
 import * as GravityObjects from '../../../src/constants/gravityObjects/GravityObjects';
 import {IResizeAction} from "../../../src/actions/resize/IResizeAction";
+import expectESMToMatchDefault from "../../TestUtils/expectESMToMatchDefault";
 
 const CONFIG_INSTANCE = new CloudinaryConfig({
   cloud: {
@@ -34,17 +35,8 @@ function getImageWithResize(resizeAction: IResizeAction, type:'url' | 'image') {
 
 
 describe('Tests for Transformation Action -- Resize', () => {
-
   it('Ensure ESM and Default export the same thing', () => {
-    (Object.keys(ResizeESM) as Array<keyof typeof ResizeESM>).forEach((funcName) => {
-      if (typeof ResizeESM[funcName] === 'function') {
-        // Ensure function exists on both objects
-        expect(ResizeESM[funcName]).toEqual((Resize as any)[funcName]);
-
-        // sanity, ensure the result is a function at all (and not an accidental undefined)
-        expect(typeof ResizeESM[funcName]).toBe('function');
-      }
-    });
+    expectESMToMatchDefault(ResizeESM, Resize);
   });
 
   it('Ensures MinimumPad generates the right URL', () => {

--- a/__TESTS__/unit/actions/Variable.test.ts
+++ b/__TESTS__/unit/actions/Variable.test.ts
@@ -1,6 +1,8 @@
 import Variable, {variable} from '../../../src/actions/variable/Variable';
+import * as VariableESM from '../../../src/actions/variable/Variable';
 import TransformableImage from '../../../src/transformation/TransformableImage';
 import CloudinaryConfig from "../../../src/config/CloudinaryConfig";
+import expectESMToMatchDefault from "../../TestUtils/expectESMToMatchDefault";
 
 const CONFIG_INSTANCE = new CloudinaryConfig({
   cloud: {
@@ -9,6 +11,10 @@ const CONFIG_INSTANCE = new CloudinaryConfig({
 });
 
 describe('Tests for Transformation Action -- Variable', () => {
+  it ('Ensures ESM Matches Default', () => {
+    expectESMToMatchDefault(VariableESM, Variable);
+  });
+
   it('Ensures Variable namespace is accepted as an action to TransformableImage', () => {
     const tImage = new TransformableImage();
     // Ensures it compiles and doesn't throw

--- a/src/transformation/Transformation.ts
+++ b/src/transformation/Transformation.ts
@@ -12,9 +12,9 @@ import ICloudinaryConfigurations from "../interfaces/Config/ICloudinaryConfigura
 import CloudinaryConfig from "../config/CloudinaryConfig";
 import {IDescriptor} from "../interfaces/IDescriptor";
 import createCloudinaryURL from "../url/cloudinaryURL";
-import RoundCorners from "../actions/roundCorners/RoundCorners";
 import {IConditionAction} from "../actions/condition/IConditionAction";
 import Param from "../parameters/Param";
+import RoundCornersAction from "../actions/roundCorners/RoundCornersAction";
 
 class Transformation {
   actions: IAction[];
@@ -93,7 +93,7 @@ class Transformation {
     return this.addAction(qualityAction);
   }
 
-  roundCorners(roundCornersAction: typeof RoundCorners): this {
+  roundCorners(roundCornersAction: RoundCornersAction): this {
     return this.addAction(roundCornersAction);
   }
 


### PR DESCRIPTION
### Pull reuqest for @Cloudianry/Base


#### What does this PR solve?
This PR reuses the ESM package test we have to reduce code duplication.
Also, fix a minor typing error in a file


#### Final checklist (All N/A)
- [ ] JSdoc - Add proper docstrings based on our PHP implementation
- [ ] JSdoc - Hide private functions using @private
- [ ] Implementation is aligned with PHP Reference(If different, please specify why)
- [ ] Tests - Add proper tests to the added code
