### PR TITLE
Implement the Test Bundle Size harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ playground/base.esm.js
 scripts/tmp.sh
 __TESTS__/compilation.test.ts
 pcakage-lock.json
+.SIZE_TESTS

--- a/__TESTS_BUNDLE_SIZE__/bin/bin.ts
+++ b/__TESTS_BUNDLE_SIZE__/bin/bin.ts
@@ -26,7 +26,9 @@ createTestFolders();
 bundleSizeTestRunner()
   .then(() => {
     // if we're in debug, we do not delete ${TMP_FOLDER}
-    testCleanUp();
+    if (!process.env.DEBUG) {
+      testCleanUp();
+    }
   })
   .catch((err) => {
     // Catch the exception thrown

--- a/__TESTS_BUNDLE_SIZE__/bin/bin.ts
+++ b/__TESTS_BUNDLE_SIZE__/bin/bin.ts
@@ -1,0 +1,43 @@
+import createDistFolder from "../utils/fileSystem/createDistFolder";
+import createTestFolders from "../utils/fileSystem/createTestFolders";
+import log from "../utils/log";
+import testCleanUp from "../utils/fileSystem/testCleanUp";
+import bundleSizeTestRunner from "../bundleSizeTestRunner";
+
+
+/**
+ * Executable entrypoint for the BundleSizeTests
+ * Run with `npm run test:size`
+ *
+ * ** Environment Variables **
+ *  - process.env.DEBUG - Used to print debug logs, also keeps the .SIZE_TESTS directory for manual inspection
+ *
+ *
+ * ** Execution Steps **
+ * 1. Ensure ./dist exists, if not, run npm run build
+ * 2. Create the needed test folders ./.SIZE_TESTS/entry, ./.SIZE_TESTS/bundles
+ * 3. run bundleSizeTestRunner
+ * 4. Cleanup all test artifacts by deleting ./.SIZE_TESTS
+ * 5. If the tests ended with an error, stop the process
+ */
+
+createDistFolder();
+createTestFolders();
+bundleSizeTestRunner()
+  .then(() => {
+    // if we're in debug, we do not delete ${TMP_FOLDER}
+    testCleanUp();
+  })
+  .catch((err) => {
+    // Catch the exception thrown
+    log.info(err);
+
+    // if we're in debug, we do not delete .${TMP_FOLDER}
+    if (!process.env.DEBUG) {
+      testCleanUp();
+    }
+    // Exit the process
+    process.exit(1);
+  });
+
+

--- a/__TESTS_BUNDLE_SIZE__/bundleSizeTestCases.ts
+++ b/__TESTS_BUNDLE_SIZE__/bundleSizeTestCases.ts
@@ -1,0 +1,63 @@
+/**
+ * This file contains the test cases for the BundleSizeTests
+ * Run all tests by running `npm run test:size`
+ */
+
+import importFromDist from "./utils/stringGenerators/importFromDist";
+import importFromBase from "./utils/stringGenerators/importFromBase";
+import {ITestCase} from "./interfaces/ITestCase";
+
+/**
+ * @description - Each test case is built using an array of imports  (importsArray)
+ *                Each element in the array is string, an import statement: `import resize from '...'; console.log(resize)`
+ *                Before we export, we combine all those strings into one long string, contained within importString;
+ */
+const bundleSizeTestCases:ITestCase[] = [
+  {
+    name: 'Tests a transformable image with Resize',
+    sizeLimitInKB: 9,
+    importsArray: [
+      importFromBase('TransformableImage'),
+      importFromDist('actions/resize')
+    ]
+  },
+  {
+    name: 'Tests a transformable image with Resize and just',
+    sizeLimitInKB: 10,
+    importsArray: [
+      importFromBase('TransformableImage'),
+      importFromDist('actions/resize'),
+      importFromDist('actions/adjust')
+    ]
+  },
+  {
+    name: 'Tests a transformable image with Resize, adjust and border',
+    sizeLimitInKB: 10.5,
+    importsArray: [
+      importFromBase('TransformableImage'),
+      importFromDist('actions/resize'),
+      importFromDist('actions/adjust'),
+      importFromDist('actions/border')
+    ]
+  },
+  {
+    name: 'Tests a transformable image with Resize, adjust and quality',
+    sizeLimitInKB: 10.5,
+    importsArray: [
+      importFromBase('TransformableImage'),
+      importFromDist('actions/resize'),
+      importFromDist('actions/adjust'),
+      importFromDist('actions/quality')
+    ]
+  }
+];
+
+/**
+ * Each case is an array of strings,
+ * Before we export, we make sure we combine them so that `importString` contains a single long string
+ */
+export default <ITestCase[]> bundleSizeTestCases.map((testCase): ITestCase => {
+  // Join all the strings into one long string, so we can write it to a file
+  testCase.importString = testCase.importsArray.join('');
+  return testCase;
+});

--- a/__TESTS_BUNDLE_SIZE__/bundleSizeTestRunner.ts
+++ b/__TESTS_BUNDLE_SIZE__/bundleSizeTestRunner.ts
@@ -1,0 +1,62 @@
+import testCases from './bundleSizeTestCases';
+import createEntryFile from "./utils/fileSystem/createEntryFile";
+import buildWithWebpack from "./utils/webpack/buildWithWebpack";
+import log from "./utils/log";
+import getBundleInfo from "./utils/fileSystem/getBundleInfo";
+import handleTestError from "./utils/testLifeCycle/handleTestError";
+import handleTestSuccess from "./utils/testLifeCycle/handleTestSuccess";
+
+/**
+ * The test runner for the BundleSize test cases
+ * Run all tests by running `npm run test:size`
+ *
+ * ** Execution Steps **
+ * 1. Fetch all test cases from ./bundleSizeTestCases
+ * 2. Iterate over the cases, for each case, do the following:
+ *    - Create an entrypoint file based on on the testCase imports
+ *    - Use webpack to build the entrypoint
+ *    - Compare the file size of the bundle compared to the test limit
+ * 3. Handle errors/success of the tests, print output
+ */
+async function bundleSizeTestRunner():Promise<void> {
+  log.info('Starting size tests, hold on!');
+  const TEST_COUNT = testCases.length;
+  let fail_count = 0;
+  for (let i = 0; i < testCases.length; i++) {
+    log.debug(`Starting tests for : ${testCases[i].name}`);
+    const ENTRY_FILE = `entry${i}`;
+    const OUTPUT_FILE = `bundle${i}`;
+    const TEST_NAME = testCases[i].name;
+    const EXPECTED_SIZE_IN_KB = testCases[i].sizeLimitInKB;
+
+    // Create the entry file for Webpack
+    log.debug('Starting to build webpack loop');
+    createEntryFile(ENTRY_FILE, testCases[i].importString);
+
+    // Build the entry file with webpack
+    log.debug('Webpack build - starting');
+    await buildWithWebpack(ENTRY_FILE, OUTPUT_FILE);
+    log.debug('Webpack build - finished');
+
+    // Get the bundle information
+    const bundleInfo = getBundleInfo(OUTPUT_FILE);
+    const ACTUAL_SIZE_IN_KB = Math.round(bundleInfo.size / 1024);
+
+    if (ACTUAL_SIZE_IN_KB <= EXPECTED_SIZE_IN_KB) {
+      handleTestSuccess(testCases[i], ACTUAL_SIZE_IN_KB);
+    } else {
+      handleTestError(TEST_NAME, EXPECTED_SIZE_IN_KB, ACTUAL_SIZE_IN_KB);
+      fail_count++;
+    }
+  }
+
+  if (fail_count === 0) {
+    log.info('Size testing done! - All OK');
+  } else {
+    throw `${fail_count}/${TEST_COUNT} Failed`;
+  }
+}
+
+
+
+export default bundleSizeTestRunner;

--- a/__TESTS_BUNDLE_SIZE__/interfaces/ITestCase.ts
+++ b/__TESTS_BUNDLE_SIZE__/interfaces/ITestCase.ts
@@ -1,0 +1,6 @@
+export interface ITestCase {
+  sizeLimitInKB: number,
+  importsArray: string[],
+  name: string,
+  importString?: string
+}

--- a/__TESTS_BUNDLE_SIZE__/utils/consts.ts
+++ b/__TESTS_BUNDLE_SIZE__/utils/consts.ts
@@ -1,0 +1,1 @@
+export const TMP_FOLDER = '.SIZE_TESTS';

--- a/__TESTS_BUNDLE_SIZE__/utils/fileSystem/createDistFolder.ts
+++ b/__TESTS_BUNDLE_SIZE__/utils/fileSystem/createDistFolder.ts
@@ -1,0 +1,17 @@
+import fs from 'fs';
+import childProcess from "child_process";
+import log from "../log";
+
+/**
+ * @description Ensures ./dist exists
+ */
+function createDistFolder():void {
+  // Create ./dist if needed
+  if (!fs.existsSync('./dist')) {
+    log.info('Could not find ./dist, running build');
+    childProcess.execSync('npm run build');
+  }
+}
+
+
+export default createDistFolder;

--- a/__TESTS_BUNDLE_SIZE__/utils/fileSystem/createEntryFile.ts
+++ b/__TESTS_BUNDLE_SIZE__/utils/fileSystem/createEntryFile.ts
@@ -1,0 +1,13 @@
+import fs from "fs";
+import log from "../log";
+import {TMP_FOLDER} from "../consts";
+
+/**
+ *
+ */
+function createEntryFile(fileName:string, str:string):void {
+  log.debug(`writing file ${fileName}`);
+  fs.writeFileSync(`./${TMP_FOLDER}/entry/${fileName}.js`, str);
+}
+
+export default createEntryFile;

--- a/__TESTS_BUNDLE_SIZE__/utils/fileSystem/createTestFolders.ts
+++ b/__TESTS_BUNDLE_SIZE__/utils/fileSystem/createTestFolders.ts
@@ -1,0 +1,13 @@
+import fs from 'fs';
+import {TMP_FOLDER} from "../consts";
+
+/**
+ * @description Sets up the test environment by creating the required folders
+ */
+function createTestFolders():void {
+  fs.mkdirSync(`./${TMP_FOLDER}/entry`, {recursive: true});
+  fs.mkdirSync(`./${TMP_FOLDER}/bundles`, {recursive: true});
+}
+
+
+export default createTestFolders;

--- a/__TESTS_BUNDLE_SIZE__/utils/fileSystem/getBundleInfo.ts
+++ b/__TESTS_BUNDLE_SIZE__/utils/fileSystem/getBundleInfo.ts
@@ -1,0 +1,13 @@
+import fs from "fs";
+import {TMP_FOLDER} from "../consts";
+
+/**
+ * Gets file information (like size, and blocks) given a path
+ * Path is relative to tmp/bundles/ for ease of use, and is appended with .js
+ * @param {string} fileName
+ */
+function getBundleInfo(fileName: string): fs.Stats {
+  return fs.statSync(`./${TMP_FOLDER}/bundles/${fileName}.js`);
+}
+
+export default getBundleInfo;

--- a/__TESTS_BUNDLE_SIZE__/utils/fileSystem/testCleanUp.ts
+++ b/__TESTS_BUNDLE_SIZE__/utils/fileSystem/testCleanUp.ts
@@ -1,0 +1,11 @@
+import fs from "fs";
+import {TMP_FOLDER} from "../consts";
+
+/**
+ * Cleans up test arifacts
+ */
+function testCleanUp():void {
+  fs.rmdirSync(`./${TMP_FOLDER}`, {recursive: true});
+}
+
+export default testCleanUp;

--- a/__TESTS_BUNDLE_SIZE__/utils/log.ts
+++ b/__TESTS_BUNDLE_SIZE__/utils/log.ts
@@ -1,0 +1,22 @@
+const DEBUG_COLOR = '\x1b[36m%s\x1b[0m'; // cyan
+const ERROR_COLOR = '\x1b[31m'; // red
+const SUCCESS_COLOR = '\x1b[32m';
+const INFO_COLOR = '\x1b[37m';
+
+class Log {
+  info(str: string) {
+    console.log(INFO_COLOR, str);
+  }
+  success(str: string) {
+    console.log(SUCCESS_COLOR, `✔ ${str}`);
+  }
+  error(str: string) {
+    console.log(ERROR_COLOR, `x ${str}`);
+  }
+  debug(str: string) {
+    process.env.DEBUG && console.log(DEBUG_COLOR, `\tDebug: ${str}`);
+  }
+}
+
+const log = new Log();
+export default log;

--- a/__TESTS_BUNDLE_SIZE__/utils/stringGenerators/importFromBase.ts
+++ b/__TESTS_BUNDLE_SIZE__/utils/stringGenerators/importFromBase.ts
@@ -1,0 +1,15 @@
+/**
+ * Utility function used to import items from the index of Base
+ * @param {string} exportedObject - The name of an exported object in index, for example TransformableImage.
+ *                                  The result will be `import {TransformableImage} from '../../dist'
+ * @returns string
+ */
+function importFromBase(exportedObject: string): string {
+  return `
+    import {${exportedObject}} from "${process.cwd()}/dist";
+    // we console log to force the bundle not to tree shake
+    console.log(${exportedObject});  
+  `;
+}
+
+export default importFromBase;

--- a/__TESTS_BUNDLE_SIZE__/utils/stringGenerators/importFromDist.ts
+++ b/__TESTS_BUNDLE_SIZE__/utils/stringGenerators/importFromDist.ts
@@ -1,0 +1,19 @@
+/**
+ * Utility function used to import items from ./dist
+ * @param {string} pathInDist - relative path inside ./dist, for example 'actions/resize'
+ *                              The result will be `import resize from '../../dist/resize`;
+ * * @returns string
+ */
+function importFromDist(pathInDist: string): string {
+  const splitBy = pathInDist.split('/');
+  const variableName = splitBy[splitBy.length - 1];
+
+  return `
+    import ${variableName} from '${process.cwd()}/dist/${pathInDist}';
+    // we console log to force the bundle not to tree shake
+    console.log(${variableName});
+  `;
+}
+
+
+export default importFromDist;

--- a/__TESTS_BUNDLE_SIZE__/utils/testLifeCycle/handleTestError.ts
+++ b/__TESTS_BUNDLE_SIZE__/utils/testLifeCycle/handleTestError.ts
@@ -1,0 +1,15 @@
+import log from "../log";
+
+/**
+ *
+ * @param name
+ * @param expected
+ * @param received
+ */
+function handleTestError(name: string, expected: number, received: number) {
+  log.error(name);
+  log.error(`\tExpected size: ${expected} KB`);
+  log.error(`\tActual size: ${received} KB\n`);
+}
+
+export default handleTestError;

--- a/__TESTS_BUNDLE_SIZE__/utils/testLifeCycle/handleTestSuccess.ts
+++ b/__TESTS_BUNDLE_SIZE__/utils/testLifeCycle/handleTestSuccess.ts
@@ -1,0 +1,12 @@
+import log from "../log";
+import {ITestCase} from "../../interfaces/ITestCase";
+
+/**
+ * @param {ITestCase} testCase
+ * @param {number} actualSizeInKB
+ */
+function handleTestSuccess(testCase: ITestCase, actualSizeInKB: number):void {
+  log.success(`${testCase.name} ${Math.round(actualSizeInKB)}KB < ${testCase.sizeLimitInKB}KB`);
+}
+
+export default handleTestSuccess;

--- a/__TESTS_BUNDLE_SIZE__/utils/webpack/buildWithWebpack.ts
+++ b/__TESTS_BUNDLE_SIZE__/utils/webpack/buildWithWebpack.ts
@@ -1,0 +1,35 @@
+import webpack from 'webpack';
+import {TMP_FOLDER} from "../consts";
+
+
+/**
+ * Build a file from ./tmp/entry/{entryFile} and output the bundle to ./tmp/bundles/{outputFile}
+ * @param {string } entryFile - The name of the file to create within ./tmp/entry/
+ * @param {string} outputFile - The name of the file to create within ./tmp/bundles/
+ * @returns Promise
+ */
+function buildWithWebpack(entryFile:string, outputFile: string):Promise<void> {
+  return new Promise((resolve, reject) => {
+    webpack({
+      entry: `./${TMP_FOLDER}/entry/${entryFile}.js`,
+      output: {
+        path: process.cwd(),
+        filename: `./${TMP_FOLDER}/bundles/${outputFile}.js`
+      }
+    }, (err, stats) => { // Stats Object
+      const info = stats.toJson();
+
+      if (err) {
+        throw err;
+        // Handle errors here
+      }
+
+      if (stats.hasErrors()) {
+        throw info.errors.toString();
+      }
+      resolve();
+    });
+  });
+}
+
+export default buildWithWebpack;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0-alpha.0",
   "description": "",
   "scripts": {
-    "test": "npm run build && jest --coverage --reporters default",
+    "test": "npm run build && jest --coverage --reporters default &&  npm run test:size",
+    "test:size": "ts-node -O '{\"module\":\"CommonJS\"}' __TESTS_BUNDLE_SIZE__/bin/bin.ts",
     "test:comp": "node ./scripts/updateCompliationTests.js && jest __TESTS__/compilation.test.ts  --coverage",
     "test:unit": "jest __TESTS__/unit --reporters default",
     "test:unit:watch": "jest __TESTS__/unit --watch",
@@ -28,6 +29,7 @@
     "@rollup/plugin-node-resolve": "^7.1.1",
     "@types/jest": "^25.2.3",
     "@types/mock-fs": "^4.10.0",
+    "@types/webpack": "^4.41.21",
     "@typescript-eslint/eslint-plugin": "^3.0.2",
     "@typescript-eslint/parser": "^3.0.2",
     "better-docs": "^2.3.0",
@@ -48,7 +50,8 @@
     "ts-node": "^8.10.2",
     "tslib": "^2.0.0",
     "typedoc": "^0.17.8",
-    "typescript": "^3.9.3"
+    "typescript": "^3.9.3",
+    "webpack": "^4.44.1"
   },
   "types": "./types/index.d.ts",
   "dependencies": {}


### PR DESCRIPTION
### Pull reuqest for @Cloudianry/Base


#### What does this PR solve?
This PR adds a test harness that runs test cases which ensure that a combination of import statements doesn't result in unwanted code.

For example, given the following input 

```javascript
import Resize from 'base/resize'
```

We would like to make sure that no extra code is added to the bundle by mistake.
While it's difficult to programmatically test it, we can manually test it once and add a guard to ensure the limits aren't breached.


A test case looks like this

```javascript
  {
    name: 'Tests a transformable image with Resize',
    sizeLimitInKB: 9,
    importsArray: [
      importFromBase('TransformableImage'), // Utility function to create the `import.... string`
      importFromDist('actions/resize') // Utility function to create the `import.... string`
    ]
  }
```

Once we have this test case, we can create a file as project entrypoint (for example `entry.js`) and use webpack to compile that file.

Webpack will import (and treeshake) everything it needs from our project, and output a minified bundled file (for example `bundle.js`).

We can now test that this output file is not larger than the `sizeLimitInKB` we've set in our test case.


**Files of interest**
- **\_\_TESTS_BUNDLE_SIZE\_\_/bin/bin.ts** - The executable file that runs the entire harness (runs through `npm run test:size`)
- **\_\_TESTS_BUNDLE_SIZE\_\_/bundleSizeTestCases.ts** - Contains all the test cases we currently have configured
- **\_\_TESTS_BUNDLE_SIZE\_\_/bundleSizeTestRunner.ts** - Contains all the logic for running the tests

**Useful information**
- Run using `npm run test:size`
- Use ENV variable DEBUG=true to see extra debug output


Example test output
<img width="777" alt="Screen Shot 2020-08-25 at 15 41 21" src="https://user-images.githubusercontent.com/59408474/91182408-d0561d00-e6f2-11ea-89c0-449cba5fda9e.png">


#### Final checklist
- [ ] JSdoc - Add proper docstrings based on our PHP implementation
- [ ] JSdoc - Hide private functions using @private
- [ ] Implementation is aligned with PHP Reference(If different, please specify why)
- [x] Tests - Add proper tests to the added code
