### PR TITLE
Reuse existing test functions

### DIFF
--- a/__TESTS__/unit/types/Gravity.test.ts
+++ b/__TESTS__/unit/types/Gravity.test.ts
@@ -3,20 +3,13 @@ import * as GravityESM from "../../../src/params/gravity/Gravity";
 
 import * as GravityObjects from "../../../src/constants/gravityObjects/GravityObjects";
 import {AutoGravity} from "../../../src/constants/gravityObjects/GravityObjects";
+import expectESMToMatchDefault from "../../TestUtils/expectESMToMatchDefault";
 
 
 
 describe('Gravity Param', () => {
   it('Ensure ESM and Default export the same thing', () => {
-    (Object.keys(GravityESM) as Array<keyof typeof GravityESM>) .forEach((funcName) => {
-      if (typeof GravityESM[funcName] === 'function') {
-        // Ensure function exists on both objects
-        expect(GravityESM[funcName]).toEqual( (Gravity as any)[funcName]);
-
-        // sanity, ensure the result is a function at all (and not an accidental undefined)
-        expect(typeof GravityESM[funcName]).toBe('function');
-      }
-    });
+    expectESMToMatchDefault(GravityESM, Gravity);
   });
 
   it('Tests simple gravitation', () => {

--- a/__TESTS__/unit/types/Position.test.ts
+++ b/__TESTS__/unit/types/Position.test.ts
@@ -1,17 +1,10 @@
 import Position from "../../../src/params/position/Position";
 import * as PositionESM from "../../../src/params/position/Position";
+import expectESMToMatchDefault from "../../TestUtils/expectESMToMatchDefault";
 
 describe('Position Param', () => {
   it('Ensure ESM and Default export the same thing', () => {
-    (Object.keys(PositionESM) as Array<keyof typeof PositionESM>) .forEach((funcName) => {
-      if (typeof PositionESM[funcName] === 'function') {
-        // Ensure function exists on both objects
-        expect(PositionESM[funcName]).toEqual( (Position as any)[funcName]);
-
-        // sanity, ensure the result is a function at all (and not an accidental undefined)
-        expect(typeof PositionESM[funcName]).toBe('function');
-      }
-    });
+    expectESMToMatchDefault(PositionESM, Position);
   });
 
   it('Tests simple gravitation', () => {


### PR DESCRIPTION
### Pull reuqest for @Cloudianry/Base


#### What does this PR solve?
Reuses the existing ESM-default tests, this was missed in a previous PR


#### Final checklist (All N/A)
- [ ] JSdoc - Add proper docstrings based on our PHP implementation
- [ ] JSdoc - Hide private functions using @private
- [ ] Implementation is aligned with PHP Reference(If different, please specify why)
- [ ] Tests - Add proper tests to the added code
