### PR TITLE
Fix ar_1.0 turning into ar_1

### DIFF
--- a/__TESTS__/unit/actions/Resize.test.ts
+++ b/__TESTS__/unit/actions/Resize.test.ts
@@ -188,4 +188,16 @@ describe('Tests for Transformation Action -- Resize', () => {
     const url = getImageWithResize(Resize.scale(100).x(1).y(2).zoom(3), 'url');
     expect(url).toContain('c_scale,w_100,x_1,y_2,z_3');
   });
+
+  it('Test aspect ratio of 1.0', () => {
+    const url = new TransformableImage('sample')
+      .setConfig(CONFIG_INSTANCE)
+      .resize(
+        Resize.fill(400)
+          .aspectRatio(1.0)
+      )
+      .toURL();
+
+    expect(url).toContain('ar_1.0');
+  });
 });

--- a/src/actions/resize/ResizeAction.ts
+++ b/src/actions/resize/ResizeAction.ts
@@ -40,7 +40,13 @@ class ResizeAction extends Action implements IAction {
   }
 
   aspectRatio(ratio:number|string): this {
-    return this.addParam(new Param('ar', ratio));
+    let usedRatio = ratio;
+
+    // if we're given a number(such as 1.0), we turn to string (1) and then add the decimal manually
+    if (usedRatio.toString().indexOf('.') === -1) {
+      usedRatio = `${usedRatio}.0`;
+    }
+    return this.addParam(new Param('ar', usedRatio));
   }
 
   gravity(gravityParam: GravityParam): this {


### PR DESCRIPTION
### Pull reuqest for @Cloudianry/Base


#### What does this PR solve?
Fixes a type issue with whole numebrs passed to aspectRatio

When 1.0 is passed, JS turns it into 1.
so aspectRatio(1.0) turns into ar_1, which is incorrect.

This PR always adds a decimal point


#### Final checklist
- [ ] JSdoc - Add proper docstrings based on our PHP implementation
- [ ] JSdoc - Hide private functions using @private
- [ ] Implementation is aligned with PHP Reference(If different, please specify why)
- [X] Tests - Add proper tests to the added code
