### PR TITLE
Remove unwanted reports from test watchmode

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test:size": "ts-node -O '{\"module\":\"CommonJS\"}' __TESTS_BUNDLE_SIZE__/bin/bin.ts",
     "test:comp": "node ./scripts/updateCompliationTests.js && jest __TESTS__/compilation.test.ts  --coverage",
     "test:unit": "jest __TESTS__/unit --reporters default",
-    "test:unit:watch": "jest __TESTS__/unit --watch",
+    "test:unit:watch": "jest __TESTS__/unit --watch --reporters default",
     "test:integration": "jest __TESTS__/integration",
     "test:integration:watch": "jest __TESTS__/integration --watch",
     "build": "bash ./scripts/build.sh",


### PR DESCRIPTION
### Pull reuqest for @Cloudianry/Base


#### What does this PR solve?
This PR prevents watch mode from building the progress report for the compilation tests (This behaviour is undesired)


#### Final checklist (All N/A)
- [ ] JSdoc - Add proper docstrings based on our PHP implementation
- [ ] JSdoc - Hide private functions using @private
- [ ] Implementation is aligned with PHP Reference(If different, please specify why)
- [ ] Tests - Add proper tests to the added code
