### PR TITLE
Force DPR to always have a decimal point

### DIFF
--- a/src/actions/delivery/dpr.ts
+++ b/src/actions/delivery/dpr.ts
@@ -6,8 +6,15 @@ import {IDeliveryAction} from "./IDeliveryAction";
  * @memberOf Actions.Delivery
  * @param {string} dpr
  */
-function dpr(dpr: string):IDeliveryAction {
-  return new DeliveryAction('dpr', dpr);
+function dpr(dpr: string|number):IDeliveryAction {
+  let useDPR = dpr.toString();
+
+  // Force DPR to contain a decimal point
+  if (dpr !== 'auto' && useDPR.indexOf('.') === -1) {
+    useDPR = `${dpr}.0`;
+  }
+
+  return new DeliveryAction('dpr', useDPR);
 }
 
 export default dpr;

--- a/src/constants/dpr/Dpr.ts
+++ b/src/constants/dpr/Dpr.ts
@@ -1,1 +1,2 @@
 export const AUTO = 'auto';
+export const auto = () => AUTO;


### PR DESCRIPTION
### Pull reuqest for @Cloudianry/Base


#### What does this PR solve?
Force DPR to always have a decimal point,
This ensures our compilation tests pass as expected, and provides a slightly better developer experience


#### Final checklist
- [ ] JSdoc - Add proper docstrings based on our PHP implementation
- [ ] JSdoc - Hide private functions using @private
- [ ] Implementation is aligned with PHP Reference(If different, please specify why)
- [ ] Tests - Add proper tests to the added code
