### PR TITLE
Feature/add type checks to tests

### DIFF
--- a/__TESTS__/unit/actions/Resize/AspectRatio.test.ts
+++ b/__TESTS__/unit/actions/Resize/AspectRatio.test.ts
@@ -35,7 +35,7 @@ describe('Tests for AspectRatio values Action -- Resize.crop', () => {
         crop().aspectRatio(AspectRatio.AR5X4())
       )
       .resize(
-        crop().aspectRatio(AspectRatio.IgnoreInitialAspectRatio())
+        crop().aspectRatio(AspectRatio.IgnoreInitialAspectRatio() as any)
       )
       .setPublicID('sample')
       .toURL();

--- a/__TESTS__/unit/config/cloudinaryConfig.test.ts
+++ b/__TESTS__/unit/config/cloudinaryConfig.test.ts
@@ -70,15 +70,18 @@ describe('Tests for CloudinaryConfiguration', () => {
     console.warn = () => {};
     const mockedFunction = jest.spyOn(console, 'warn');
 
-    new CloudinaryConfig({
+    const config = {
       cloud:{
         'fakeKey': true,
         cloudName:'foo'
       },
       url: {
-        'fakeKey': true
+        'fakeKey': true,
+        secure: true
       }
-    });
+    };
+
+    new CloudinaryConfig(config);
 
     // ensure expected result
     expect(mockedFunction).toHaveBeenCalledTimes(2);
@@ -97,12 +100,12 @@ describe('Tests for CloudinaryConfiguration', () => {
 
     // Configs expect objects as input, but we allow invalid types without throwing
     expect(() => {
-      new CloudConfig('foo');
+      new CloudConfig('foo' as any);
     }).toThrow();
     expect(new URLConfig('foo')).toEqual({});
 
     expect(() => {
-      new CloudConfig([]);
+      new CloudConfig([] as any);
     }).toThrow();
     expect(new URLConfig([])).toEqual({});
 

--- a/__TESTS__/unit/transformation/Transformation.test.ts
+++ b/__TESTS__/unit/transformation/Transformation.test.ts
@@ -41,20 +41,4 @@ describe('Tests for Transformation', () => {
       .toURL()
     ).toBe('http://res.cloudinary.com/demo/avatar/fetch/v1234/sample');
   });
-
-  it('When providing actions with a toString method, should concat all child strings', () => {
-    transformation
-      .addAction({
-        toString() {
-          return 'aa';
-        }
-      })
-      .addAction({
-        toString() {
-          return 'bb';
-        }
-      });
-
-    expect(transformation.toString()).toBe('aa/bb');
-  });
 });

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0-alpha.1",
   "description": "",
   "scripts": {
-    "test": "npm run build && jest --coverage --reporters default &&  npm run test:size",
+    "test": "npm run test:types && npm run build && jest --coverage --reporters default &&  npm run test:size",
     "test:size": "ts-node -O '{\"module\":\"CommonJS\"}' __TESTS_BUNDLE_SIZE__/bin/bin.ts",
     "test:comp": "node ./scripts/updateCompliationTests.js && jest __TESTS__/compilation.test.ts  --coverage",
     "test:unit": "jest __TESTS__/unit --reporters default",
@@ -11,7 +11,8 @@
     "test:integration": "jest __TESTS__/integration",
     "test:integration:watch": "jest __TESTS__/integration --watch",
     "build": "bash ./scripts/build.sh",
-    "build:ESM": "tsc --project ./tsconfig.json",
+    "test:types": "tsc --project tsconfig.test.json",
+    "build:ESM": "tsc --project tsconfig.json",
     "build:UMD": "rollup -c",
     "build:docs": "node ./scripts/buildDocs.js",
     "build:entryPoints": "ts-node ./scripts/createEntrypoints.ts",

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -8,6 +8,7 @@
     "noEmit": true
   },
   "include": [
-    "__TESTS__"
+    "__TESTS__",
+    "__TESTS_BUNDLE_SIZE__"
   ]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "noImplicitAny": true,
+    "declaration": true,
+    "module": "ES2015",
+    "baseUrl": "src",
+    "moduleResolution": "node",
+    "esModuleInterop": true
+  },
+  "include": [
+    "__TESTS__"
+  ]
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,11 +1,11 @@
 {
   "compilerOptions": {
     "noImplicitAny": true,
-    "declaration": true,
     "module": "ES2015",
     "baseUrl": "src",
     "moduleResolution": "node",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "noEmit": true
   },
   "include": [
     "__TESTS__"


### PR DESCRIPTION
### Pull reuqest for @Cloudianry/Base


#### What does this PR solve?
We don't currently apply any form of type checking against our test files.
You can have incorrect types in __TESTS__ and there will be no error thrown during tests or build.

This PR fixes that by adding a command to type-check __TESTS__ and __TESTS_BUNDLE_SIZE__

This also exposed an issue with our types in aspectRatio

#### Final checklist
- [ ] JSdoc - Add proper docstrings based on our PHP implementation
- [ ] JSdoc - Hide private functions using @private
- [ ] Implementation is aligned to Spec.
- [ ] Tests - Add proper tests to the added code
