### PR TITLE
Export cloudinary instance as the default

### DIFF
--- a/__TESTS__/unit/namespaces/Index.test.ts
+++ b/__TESTS__/unit/namespaces/Index.test.ts
@@ -1,8 +1,9 @@
-import CloudinaryBase, {Actions} from "../../../src/index";
+import CloudinaryInstance from '../../../src/instance/Cloudinary';
+import Cloudinary, {Actions} from "../../../src/index";
 
 describe('Tests for the Main index namespace', () => {
   it('Test that Index exports Actions correctly', () => {
-    expect(CloudinaryBase.Actions).toBe(Actions);
+    expect(Cloudinary).toBe(CloudinaryInstance);
     expect(Actions.Resize).not.toBeUndefined();
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,9 @@ import Transformation from "./transformation/Transformation";
 import cloudinaryURL from "./url/cloudinaryURL";
 import TransformableImage from "./transformation/TransformableImage";
 import Actions from './actions/Actions';
+import Cloudinary from "./instance/Cloudinary";
 
 
-export {cloudinaryURL, Transformation, TransformableImage, Actions};
-export default {cloudinaryURL, Transformation, Actions};
+export {cloudinaryURL, Transformation, TransformableImage, Actions, Cloudinary};
+export default Cloudinary;
+


### PR DESCRIPTION
### Pull reuqest for @Cloudianry/Base


#### What does this PR solve?
This PR exports the Cloudinary Instance as the default export


#### Final checklist
- [ ] JSdoc - Add proper docstrings based on our PHP implementation
- [ ] JSdoc - Hide private functions using @private
- [ ] Implementation is aligned to Spec.
- [ ] Tests - Add proper tests to the added code
