### PR TITLE
Fix a problem with package.json version after release

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -1,0 +1,7 @@
+{
+  "plugins": {
+    "@release-it/bumper": {
+      "out": ["package.json", "../package.json"]
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.9.0",
     "@babel/preset-env": "^7.9.0",
+    "@release-it/bumper": "^2.0.0",
     "@rollup/plugin-node-resolve": "^7.1.1",
     "@types/jest": "^25.2.3",
     "@types/mock-fs": "^4.10.0",


### PR DESCRIPTION
### Pull reuqest for @Cloudianry/Base


#### What does this PR solve?
This PR fixes an issue where a version release would not bump the version in pacakge.json.
This would happen because the bump script would run on the ./dist/package.json, and not on the package itself.

The fix was done by adding a plugin to release-it (official plugin) that updates multiple files, and not just the default one.

