### PR TITLE
Add support for NodeJS require() syntax

### DIFF
--- a/__TESTS__/unit/scripts/createEntryPoints.test.ts
+++ b/__TESTS__/unit/scripts/createEntryPoints.test.ts
@@ -18,7 +18,8 @@ describe('Tests for createEntryPoints', () => {
     const mainPackageJson = JSON.parse(fs.readFileSync('./dist/package.json', 'utf-8'));
 
     // Expect the right main entrypoint
-    expect(mainPackageJson.main).toBe('./index.js');
+    expect(mainPackageJson.main).toBe('./bundles/umd/base.js');
+    expect(mainPackageJson.browser).toBe('./index.js');
     // Expect not to delete existing values
     expect(mainPackageJson.fieldA).toBe('foobar');
     expect(mainPackageJson.sideEffects).toBe(false);

--- a/scripts/lib/entryPointsLib.ts
+++ b/scripts/lib/entryPointsLib.ts
@@ -36,7 +36,8 @@ function createMainEntryPoint() {
   const projectJson = JSON.parse(fs.readFileSync('./package.json', 'utf-8'));
   delete projectJson.scripts;
   delete projectJson.devDependencies;
-  projectJson.main = './index.js';
+  projectJson.main = './bundles/umd/base.js';
+  projectJson.browser = './index.js';
 
   Object.assign(projectJson, commonPackageProperties);
   fs.writeFileSync('./dist/package.json', JSON.stringify(projectJson, null, '\t'));


### PR DESCRIPTION
### Pull reuqest for @Cloudianry/Base
- Enable require() from node
- Preserve bundle size and tree shaking for bundlers

#### What does this PR solve?
This PR adds a browser and a main field to the package.json
This was tested manually with multiple bundlers and node
