### PR TITLE
Fix a bug in the budle size tester that reported incorrect sizes

### DIFF
--- a/__TESTS_BUNDLE_SIZE__/utils/stringGenerators/importFromDist.ts
+++ b/__TESTS_BUNDLE_SIZE__/utils/stringGenerators/importFromDist.ts
@@ -9,7 +9,7 @@ function importFromDist(pathInDist: string): string {
   const variableName = splitBy[splitBy.length - 1];
 
   return `
-    import ${variableName} from '${process.cwd()}/dist/${pathInDist}';
+    import * as ${variableName} from '${process.cwd()}/dist/${pathInDist}';
     // we console log to force the bundle not to tree shake
     console.log(${variableName});
   `;


### PR DESCRIPTION
### Pull request for @Cloudinary/Base


#### What does this PR solve?
The Bundle Size tester attemps to bundle code based on an import path provided by a function.
We recently removed all default exports from the SDK, and left only the named exports.

The import function of the bundle size was importing from `default`, this fix changes it to `import * from` which is no longer the default import.
