### PR TITLE
Align PSDTools to support multiple qualifiers in a row

### DIFF
--- a/__TESTS__/unit/actions/PSDTools.test.ts
+++ b/__TESTS__/unit/actions/PSDTools.test.ts
@@ -1,8 +1,6 @@
-import * as PSDTools from "../../../src/actions/psdTools/PsdTools";
 import TransformableImage from '../../../src/transformation/TransformableImage';
 import CloudinaryConfig from "../../../src/config/CloudinaryConfig";
-import * as PSDToolsESM from '../../../src/actions/psdTools/PsdTools';
-
+import {PSDTools} from "../../../src/actions/Actions";
 
 const CONFIG_INSTANCE = new CloudinaryConfig({
   cloud: {
@@ -91,4 +89,24 @@ describe('Tests for Transformation Action -- PSDTools', () => {
     expect(url).toBe('https://res.cloudinary.com/demo/image/upload/pg_embedded:name:myFile/sample');
   });
 
+  it('Uses multiple qualifiers', () => {
+    expect(PSDTools
+      .getLayer()
+      .byNumber(1)
+      .byRange(5, 7)
+      .toString()
+    ).toBe('pg_1;5-7'); // pg_1;5-7
+    expect(PSDTools
+      .getLayer()
+      .byRange(4, 7)
+      .byNumber(9)
+      .toString()
+    ).toBe('pg_4-7;9');
+    expect(PSDTools
+      .getLayer()
+      .byName("lala")
+      .byName('fofo')
+      .toString()
+    ).toBe('pg_name:lala;fofo');
+  });
 });

--- a/src/actions/psdTools/GetLayerAction.ts
+++ b/src/actions/psdTools/GetLayerAction.ts
@@ -10,12 +10,12 @@ import QualifierValue from "../../qualifier/QualifierValue";
  * @augments Action
  */
 class GetLayerAction extends Action {
-  private from: string | number;
-  private to: string | number;
   private name: string;
+  private qualifierValue = new QualifierValue();
 
   constructor() {
     super();
+    this.qualifierValue.delimiter = ';';
   }
 
   /**
@@ -23,7 +23,8 @@ class GetLayerAction extends Action {
    * @param {string|number} from The layer number
    */
   byNumber(from: string|number): this{
-    this.from = from;
+
+    this.qualifierValue.addValue(from);
     return this;
   }
 
@@ -33,8 +34,11 @@ class GetLayerAction extends Action {
    * @param {string|number} to The layer number
    */
   byRange(from: string|number, to: string|number): this{
-    this.from = from;
-    this.to = to;
+    const range = new QualifierValue(from);
+    range.addValue(to);
+    range.delimiter = '-';
+
+    this.qualifierValue.addValue(range);
     return this;
   }
 
@@ -44,17 +48,16 @@ class GetLayerAction extends Action {
    */
   byName(name: string): this{
     this.name = name;
+    this.qualifierValue.addValue(name);
     return this;
   }
+
   protected prepareQualifiers(): this {
-    let qualifierValue;
+    let qualifierValue = this.qualifierValue;
     if(this.name) {
-      qualifierValue = new QualifierValue(['name', `${this.name}`]).setDelimiter(':');
-    } else if(this.from && this.to) {
-      qualifierValue = new QualifierValue(`${this.from}-${this.to}`);
-    }else if(this.from && !this.to){
-      qualifierValue = new QualifierValue(`${this.from}`);
+      qualifierValue = new QualifierValue(['name', this.qualifierValue]).setDelimiter(':');
     }
+
     this.addQualifier(new Qualifier('pg', qualifierValue));
     return this;
   }

--- a/src/actions/psdTools/PsdTools.ts
+++ b/src/actions/psdTools/PsdTools.ts
@@ -9,36 +9,37 @@ import SmartObjectAction from "./SmartObjectAction";
  * @memberOf Actions
  * @namespace PSDTools
  */
+class PSDTools {
+  /**
+   * @description  Trims the pixels of a PSD image according to a Photoshop clipping path that is stored in the image's metadata.
+   * @memberOf Actions.PSDTools
+   * @param {string|number} path Number or the name of the clipping path.
+   * @return {ClipAction}
+   */
+  static clip(path: string|number): ClipAction {
+    return new ClipAction(path);
+  }
 
+  /**
+   * @description Delivers an image containing only specified layers of a Photoshop image.
+   *
+   * <b>Learn more:</b> {@link https://cloudinary.com/documentation/paged_and_layered_media#deliver_selected_layers_of_a_psd_image | Deliver selected layers of a PSD image}
+   * @memberOf Actions.PSDTools
+   * @return {GetLayerAction}
+   */
+  static getLayer(): GetLayerAction {
+    return new GetLayerAction();
+  }
 
-/**
- * @description  Trims the pixels of a PSD image according to a Photoshop clipping path that is stored in the image's metadata.
- * @memberOf Actions.PSDTools
- * @param {string|number} path Number or the name of the clipping path.
- * @return {ClipAction}
- */
-function clip(path: string|number): ClipAction{
-  return new ClipAction(path);
+  /**
+   * @description Extracts the original content of an embedded object of a Photoshop image.
+   * @memberOf Actions.PSDTools
+   * @return {SmartObjectAction}
+   */
+  static smartObject(): SmartObjectAction {
+    return new SmartObjectAction();
+  }
 }
 
-/**
- * @description Delivers an image containing only specified layers of a Photoshop image.
- *
- * <b>Learn more:</b> {@link https://cloudinary.com/documentation/paged_and_layered_media#deliver_selected_layers_of_a_psd_image | Deliver selected layers of a PSD image}
- * @memberOf Actions.PSDTools
- * @return {GetLayerAction}
- */
-function getLayer(): GetLayerAction{
-  return new GetLayerAction();
-}
-
-/**
- * @description Extracts the original content of an embedded object of a Photoshop image.
- * @memberOf Actions.PSDTools
- * @return {SmartObjectAction}
- */
-function smartObject(): SmartObjectAction {
-  return new SmartObjectAction();
-}
-
+const {clip, getLayer, smartObject} = PSDTools;
 export {clip, getLayer, smartObject};

--- a/src/transformation/Transformation.ts
+++ b/src/transformation/Transformation.ts
@@ -29,6 +29,9 @@ import {StyleTransfer} from "../actions/effect/styleTransfer";
 import {VectorizeEffectAction} from "../actions/effect/vectorize";
 import {GradientFadeEffectAction} from "../actions/effect/gradientFade";
 import DeliveryAction from "../actions/delivery/DeliveryAction";
+import SmartObjectAction from "../actions/psdTools/SmartObjectAction";
+import ClipAction from "../actions/psdTools/ClipAction";
+import GetLayerAction from "../actions/psdTools/GetLayerAction";
 
 declare type videoEditType = VolumeAction | TrimAction | ConcatenateAction;
 declare type EffectActions =
@@ -247,7 +250,7 @@ class Transformation {
    * @description Adds a layer in a Photoshop document.
    * @param action
    */
-  psdTools(action: Action): this {
+  psdTools(action: SmartObjectAction | ClipAction | GetLayerAction): this {
     return this.addAction(action);
   }
 

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -8,6 +8,7 @@
     "noEmit": true
   },
   "include": [
+    "src",
     "__TESTS__",
     "__TESTS_BUNDLE_SIZE__"
   ]


### PR DESCRIPTION
### Pull request for @Cloudinary/Base


#### What does this PR solve?
- Align PSDTools to support multiple qualifiers in a row
- Add src folder for tsconfig.test for better type checking in development

#### Final checklist
- [X] JSdoc - Add proper docstrings based on our PHP implementation
- [X] JSdoc - Hide private functions using @private
- [X] Implementation is aligned to Spec.
- [X] Tests - Add proper tests to the added code
