### PR TITLE
Align smart object to use multiple qualifiers

### DIFF
--- a/__TESTS__/unit/actions/PSDTools.test.ts
+++ b/__TESTS__/unit/actions/PSDTools.test.ts
@@ -74,21 +74,21 @@ describe('Tests for Transformation Action -- PSDTools', () => {
   it('Creates a cloudinaryURL with smartObject.byIndex', () => {
     const url = new TransformableImage()
       .setConfig(CONFIG_INSTANCE)
-      .psdTools(PSDTools.smartObject().byIndex(8))
+      .psdTools(PSDTools.smartObject().byIndex(8).byIndex(5))
       .setPublicID('sample')
       .toURL();
 
-    expect(url).toBe('https://res.cloudinary.com/demo/image/upload/pg_embedded:8/sample');
+    expect(url).toBe('https://res.cloudinary.com/demo/image/upload/pg_embedded:8;5/sample');
   });
 
   it('Creates a cloudinaryURL with smartObject.byFileName', () => {
     const url = new TransformableImage()
       .setConfig(CONFIG_INSTANCE)
-      .psdTools(PSDTools.smartObject().byFileName('myFile'))
+      .psdTools(PSDTools.smartObject().byFileName('myFile').byFileName('myFile2'))
       .setPublicID('sample')
       .toURL();
 
-    expect(url).toBe('https://res.cloudinary.com/demo/image/upload/pg_embedded:name:myFile/sample');
+    expect(url).toBe('https://res.cloudinary.com/demo/image/upload/pg_embedded:name:myFile;myFile2/sample');
   });
 
 });

--- a/src/actions/psdTools/SmartObjectAction.ts
+++ b/src/actions/psdTools/SmartObjectAction.ts
@@ -12,8 +12,11 @@ import QualifierValue from "../../qualifier/QualifierValue";
  */
 class SmartObjectAction extends Action{
   private smartObjectValue: string|number;
+  private qualifierValue = new QualifierValue();
+  private useName = false;
   constructor() {
     super();
+    this.qualifierValue.delimiter = ';';
   }
 
   /**
@@ -22,6 +25,7 @@ class SmartObjectAction extends Action{
    */
   byIndex(index: string|number): this{
     this.smartObjectValue = index;
+    this.qualifierValue.addValue(index);
     return this;
   }
 
@@ -30,12 +34,18 @@ class SmartObjectAction extends Action{
    * @param fileName The name
    */
   byFileName(fileName:string): this{
-    this.smartObjectValue = `name:${fileName}`;
+    this.useName = true;
+    this.qualifierValue.addValue(fileName);
     return this;
   }
 
   protected prepareQualifiers() : void {
-    const qualifierValue = new QualifierValue(['embedded', `${this.smartObjectValue}`]).setDelimiter(':');
+    let qualifierValue;
+    if (this.useName) {
+      qualifierValue = new QualifierValue(['embedded:name', this.qualifierValue]);
+    } else {
+      qualifierValue = new QualifierValue(['embedded', this.qualifierValue]);
+    }
 
     this.addQualifier(new Qualifier('pg', qualifierValue));
   }


### PR DESCRIPTION
### Pull request for @Cloudinary/Base


#### What does this PR solve?
Align smart object to use multiple qualifiers


#### Final checklist
- [X] JSdoc - Add proper docstrings based on our PHP implementation
- [X] JSdoc - Hide private functions using @private
- [X] Implementation is aligned to Spec.
- [X] Tests - Add proper tests to the added code
