### PR TITLE
Align pad to spec by improving types

### DIFF
--- a/__TESTS__/unit/actions/Resize/FillPadAction.test.ts
+++ b/__TESTS__/unit/actions/Resize/FillPadAction.test.ts
@@ -18,10 +18,10 @@ describe('Tests for Transformation Action -- Resize.fillPad', () => {
         .height(250)
         .x(10)
         .y(10)
-        .gravity(Gravity.compass(Compass.north()))
+        .gravity(Gravity.autoGravity())
         .aspectRatio(1.2)
         .background(Background.color('red')),
       'url');
-    expect(url).toContain('ar_1.2,b_red,c_fill_pad,g_north,h_250,w_250,x_10,y_10');
+    expect(url).toContain('ar_1.2,b_red,c_fill_pad,g_auto,h_250,w_250,x_10,y_10');
   });
 });

--- a/src/actions/resize/ResizeActions/pad/FillPadAction.ts
+++ b/src/actions/resize/ResizeActions/pad/FillPadAction.ts
@@ -1,4 +1,5 @@
 import ResizePadAction from "../shared/ResizePadAction";
+import {AutoGravity} from "../../../../values/gravity/autoGravity/AutoGravity";
 
 /**
  * @memberOf Actions.Resize
@@ -15,7 +16,7 @@ import ResizePadAction from "../shared/ResizePadAction";
  * @param {number|string} height The required height of a transformed asset.
  * @return {ResizePadAction}
  */
-function fillPad(width?: string|number, height?: string|number) :ResizePadAction {
+function fillPad(width?: string|number, height?: string|number) :ResizePadAction<AutoGravity> {
   return new ResizePadAction('fill_pad', width, height);
 }
 

--- a/src/actions/resize/ResizeActions/pad/LimitPadAction.ts
+++ b/src/actions/resize/ResizeActions/pad/LimitPadAction.ts
@@ -1,4 +1,5 @@
 import ResizePadAction from "../shared/ResizePadAction";
+import {CompassGravity} from "../../../../values/gravity/compassGravity/CompassGravity";
 
 /**
  * @description
@@ -13,7 +14,7 @@ import ResizePadAction from "../shared/ResizePadAction";
  * @param {number|string} height The required height of a transformed asset.
  * @return {ResizePadAction}
  */
-function limitPad(width?: string|number, height?: string|number) :ResizePadAction {
+function limitPad(width?: string|number, height?: string|number) :ResizePadAction<CompassGravity> {
   return new ResizePadAction('lpad', width, height);
 }
 

--- a/src/actions/resize/ResizeActions/pad/MinimumPadAction.ts
+++ b/src/actions/resize/ResizeActions/pad/MinimumPadAction.ts
@@ -1,4 +1,5 @@
 import ResizePadAction from "../shared/ResizePadAction";
+import {CompassGravity} from "../../../../values/gravity/compassGravity/CompassGravity";
 
 /**
  * @description
@@ -12,7 +13,7 @@ import ResizePadAction from "../shared/ResizePadAction";
  * @param {number|string} height The required height of a transformed asset.
  * @return {ResizePadAction}
  */
-function minimumPad(width?: string|number, height?: string|number) :ResizePadAction {
+function minimumPad(width?: string|number, height?: string|number) :ResizePadAction<CompassGravity> {
   return new ResizePadAction('mpad', width, height);
 }
 

--- a/src/actions/resize/ResizeActions/pad/PadAction.ts
+++ b/src/actions/resize/ResizeActions/pad/PadAction.ts
@@ -1,4 +1,5 @@
 import ResizePadAction from "../shared/ResizePadAction";
+import {CompassGravity} from "../../../../values/gravity/compassGravity/CompassGravity";
 
 /**
  * @description
@@ -11,7 +12,7 @@ import ResizePadAction from "../shared/ResizePadAction";
  * @param {number|string} height The required height of a transformed asset.
  * @return {ResizePadAction}
  */
-function pad(width?: string|number, height?: string|number) :ResizePadAction {
+function pad(width?: string|number, height?: string|number) :ResizePadAction<CompassGravity> {
   return new ResizePadAction('pad', width, height);
 }
 

--- a/src/actions/resize/ResizeActions/shared/ResizePadAction.ts
+++ b/src/actions/resize/ResizeActions/shared/ResizePadAction.ts
@@ -1,5 +1,6 @@
 import ResizeAdvancedActionWithPosition from "./ResizeAdvancedActionWithPosition";
 import {BackgroundQualifier} from "../../../../values/background/shared/base/BackgroundQualifier";
+import {IGravity} from "../../../../values/gravity/GravityQualifier";
 
 
 /**
@@ -7,7 +8,7 @@ import {BackgroundQualifier} from "../../../../values/background/shared/base/Bac
  * @class ResizePadAction
  * @augments ResizeAdvancedActionWithPosition
  */
-class ResizePadAction extends ResizeAdvancedActionWithPosition {
+class ResizePadAction<GravityType extends IGravity> extends ResizeAdvancedActionWithPosition {
   /**
    * @description Sets the background.
    * @param {Values.Background} backgroundQualifier Defines the background color to use instead of
@@ -15,6 +16,10 @@ class ResizePadAction extends ResizeAdvancedActionWithPosition {
    */
   background(backgroundQualifier: BackgroundQualifier): this {
     return this.addQualifier(backgroundQualifier);
+  }
+
+  gravity(direction:GravityType): this {
+    return this.addQualifier(direction);
   }
 }
 


### PR DESCRIPTION
### Align pad to spec by improving types


#### What does this PR solve?
- Ensure all Resize.pad actions have accurate Gravity types
- Change ResizePad to accept a generic type for Gravity
- Fix resulting bugs in the tests (invalid gravity types used for some resize actions) 


#### Final checklist
- [X] JSdoc - Add proper docstrings based on our PHP implementation
- [X] Implementation is aligned to Spec.
- [X] Tests - Add proper tests to the added code
