### PR TITLE
Remove explicit Buffer calls from the code

### DIFF
--- a/src/internal/utils/base64Encode.ts
+++ b/src/internal/utils/base64Encode.ts
@@ -5,17 +5,12 @@
  * @param {string} input - A string to encode with base64
  */
 function base64Encode(input: string):string {
-  // These else conditions cannot be reasonably tested through Jest,
-  // as Jest runs in a Node environment, and the point of this code is to be isomorphic
-  /* istanbul ignore else */
-  if (typeof Buffer !== 'undefined') {
-    return Buffer.from(input).toString('base64');
-  } else if (typeof btoa === 'function') {
+  // Browser
+  if (typeof window !== 'undefined') {
     return btoa(input);
   } else {
-    // If for some reason we don't have buffer or atb, silently return a string
-    // this is to avoid exceptions to be thrown from outside of this function
-    return '';
+    // NodeJS support
+    return global.Buffer.from(input).toString('base64');
   }
 }
 


### PR DESCRIPTION
### Pull request for @Cloudinary/Base
Remove explicit Buffer calls from the code

Using `Buffer` (without `global.Buffer`) results in typescript injecting Buffer.js into the ode
Buffer.js is a module dedicated to polyfill node's Buffer in the browser, clearly not needed in our project

This PR removes `typeof Buffer` and replaces it with a different check
