### PR TITLE
Various alignments to the code generator

### DIFF
--- a/__TESTS__/unit/actions/Delivery.test.ts
+++ b/__TESTS__/unit/actions/Delivery.test.ts
@@ -24,7 +24,7 @@ describe('Tests for Transformation Action -- Delivery', () => {
   it('Creates a cloudinaryURL with format using string', () => {
     const url = new CloudinaryImage()
       .setConfig(CONFIG_INSTANCE)
-      .delivery(Delivery.format('auto'))
+      .delivery(Delivery.format(Format.auto()))
       .setPublicID('sample')
       .toURL();
 
@@ -295,7 +295,7 @@ describe('Tests for Transformation Action -- Delivery', () => {
   it('Creates a cloudinaryURL with Delivery.colorspace', () => {
     const url = new CloudinaryImage()
       .setConfig(CONFIG_INSTANCE)
-      .delivery(Delivery.colorSpace(ColorSpace.noCMYK()))
+      .delivery(Delivery.colorSpace(ColorSpace.noCmyk()))
       .setPublicID('sample')
       .toURL();
 

--- a/__TESTS__/unit/actions/Effect.test.ts
+++ b/__TESTS__/unit/actions/Effect.test.ts
@@ -37,7 +37,7 @@ describe('Tests for Transformation Action -- Effect', () => {
       .effect(Effect.grayscale())
       .effect(Effect.loop())
       .effect(Effect.loop(100))
-      .effect(Effect.loop().iterations(5))
+      .effect(Effect.loop().additionalIterations(5))
       .effect(Effect.makeTransparent())
       .effect(Effect.makeTransparent(100))
       .effect(Effect.makeTransparent().tolerance(5))

--- a/__TESTS__/unit/actions/Effect.test.ts
+++ b/__TESTS__/unit/actions/Effect.test.ts
@@ -29,11 +29,11 @@ describe('Tests for Transformation Action -- Effect', () => {
       .effect(Effect.boomerang())
       .effect(Effect.blackwhite())
       .effect(Effect.blackwhite(10))
-      .effect(Effect.blackwhite().level(20))
+      .effect(Effect.blackwhite().threshold(20))
       .effect(Effect.fadeIn(100))
       .effect(Effect.fadeIn().length(5))
       .effect(Effect.fadeOut(100))
-      .effect(Effect.fadeOut().length(5))
+      .effect(Effect.fadeOut().duration(5))
       .effect(Effect.grayscale())
       .effect(Effect.loop())
       .effect(Effect.loop(100))
@@ -147,11 +147,11 @@ describe('Tests for Transformation Action -- Effect', () => {
   it('Creates a cloudinaryURL with effect oilPaint', () => {
     const url = new CloudinaryImage()
       .setConfig(CONFIG_INSTANCE)
-      .effect(Effect.oilPaint())
+      .effect(Effect.oilPaint().strength(10))
       .setPublicID('sample')
       .toURL();
 
-    expect(url).toBe('https://res.cloudinary.com/demo/image/upload/e_oil_paint/sample');
+    expect(url).toBe('https://res.cloudinary.com/demo/image/upload/e_oil_paint:10/sample');
   });
 
   it('Creates a cloudinaryURL with effect oilPaint:level', () => {

--- a/__TESTS__/unit/actions/Overlay.test.ts
+++ b/__TESTS__/unit/actions/Overlay.test.ts
@@ -156,7 +156,6 @@ describe('Tests for overlay actions', () => {
   it('Tests a fetchSource with format', () => {
     const asset = createNewImage('sample');
     const REMOTE_URL = "https://res.cloudinary.com/demo/image/upload/ci";
-    const BASE64_URL = base64Encode(REMOTE_URL);
 
     asset.overlay(
       Overlay.source(
@@ -167,6 +166,7 @@ describe('Tests for overlay actions', () => {
     );
 
     // This is a fully functional URL that should work in the browser.
-    expect(asset.toString()).toContain(`l_fetch:${BASE64_URL}.png/${sampleTxResizePad().toString()}`);
+    // Explicitly check the resulting base64 string
+    expect(asset.toString()).toContain(`l_fetch:aHR0cHM6Ly9yZXMuY2xvdWRpbmFyeS5jb20vZGVtby9pbWFnZS91cGxvYWQvY2k=.png/${sampleTxResizePad().toString()}`);
   });
 });

--- a/__TESTS__/unit/actions/Pixelate/Pixelate.test.ts
+++ b/__TESTS__/unit/actions/Pixelate/Pixelate.test.ts
@@ -2,26 +2,26 @@ import {Region} from "../../../../src/values/region";
 import {Effect} from "../../../../src/actions/effect";
 
 describe('Tests for Transformation Action -- Pixelate', () => {
-  it('Tests pixelate with and without pixelWidth', () => {
+  it('Tests pixelate with and without squareSize', () => {
     expect(Effect.pixelate()
       .toString()
     ).toEqual('e_pixelate');
 
     expect(Effect.pixelate()
-      .pixelWidth(10)
+      .squareSize(10)
       .toString()
     ).toEqual('e_pixelate:10');
   });
 
   it('Test pixelate:faces', () => {
     expect(Effect.pixelate()
-      .pixelWidth(50)
+      .squareSize(50)
       .region(Region.faces()).toString()).toBe('e_pixelate_faces:50');
   });
 
   it('Test pixelate custom region', () => {
     expect(Effect.pixelate()
-      .pixelWidth(10)
+      .squareSize(10)
       .region(Region.custom()
         .height(20)
         .width(30)
@@ -35,7 +35,7 @@ describe('Tests for Transformation Action -- Pixelate', () => {
 
   it('Test pixelate with Region.ocr', () => {
     expect(Effect.pixelate()
-      .pixelWidth(10)
+      .squareSize(10)
       .region(Region.ocr()
       )
       .toString()

--- a/__TESTS__/unit/actions/Resize.test.ts
+++ b/__TESTS__/unit/actions/Resize.test.ts
@@ -1,5 +1,6 @@
 import getImageWithResize from "./Resize/shared/getImageWithResize";
 import * as Resize from "../../../src/actions/resize";
+import {Expression} from "../../../src/values/expression";
 
 
 describe('Tests for Transformation Action -- Resize', () => {
@@ -11,5 +12,10 @@ describe('Tests for Transformation Action -- Resize', () => {
   it('Resize with a resize mode - region_relative', () => {
     const url = getImageWithResize(Resize.scale(100).regionRelative(), 'url');
     expect(url).toContain('c_scale,fl_region_relative,w_100');
+  });
+
+  it('Resize with an expression', () => {
+    const url = getImageWithResize(Resize.scale().width(Expression.expression('100 + 5')), 'url');
+    expect(url).toContain('c_scale,w_100_add_5');
   });
 });

--- a/__TESTS__/unit/actions/RoundCorners.test.ts
+++ b/__TESTS__/unit/actions/RoundCorners.test.ts
@@ -44,6 +44,14 @@ describe('Tests for Transformation Action -- RoundCorners', () => {
     expect(url).toContain('r_25:20:15:10');
   });
 
+  it('Ensure roundCorners accepts 4 radius, including zeroes', () => {
+    const url = new CloudinaryImage('sample')
+      .setConfig(CONFIG_INSTANCE)
+      .roundCorners(byRadius(25, 0, 0, 0))
+      .toURL();
+    expect(url).toContain('r_25:0:0:0');
+  });
+
   it('Ensure roundCorners accepts max radius', () => {
     const url = new CloudinaryImage('sample')
       .setConfig(CONFIG_INSTANCE)

--- a/__TESTS__/unit/actions/VideoEdit.test.ts
+++ b/__TESTS__/unit/actions/VideoEdit.test.ts
@@ -71,6 +71,20 @@ describe('Tests for Transformation Action -- VideoEdit', () => {
     expect(url).toBe('https://res.cloudinary.com/demo/video/upload/du_10,eo_4,so_3/sample');
   });
 
+  it('Creates a cloudinaryURL with trim %', () => {
+    const url = new CloudinaryVideo()
+      .setConfig(CONFIG_INSTANCE)
+      .videoEdit(VideoEdit.trim()
+        .startOffset('3%')
+        .endOffset('4%')
+        .duration('10%'))
+      .setAssetType('video')
+      .setPublicID('sample')
+      .toURL();
+
+    expect(url).toBe('https://res.cloudinary.com/demo/video/upload/du_10p,eo_4p,so_3p/sample');
+  });
+
   it('Creates a cloudinaryURL with volume string', () => {
     const url = new CloudinaryVideo()
       .setConfig(CONFIG_INSTANCE)

--- a/__TESTS__/unit/values/valueImports.test.ts
+++ b/__TESTS__/unit/values/valueImports.test.ts
@@ -71,12 +71,12 @@ describe('Test imported values', () => {
     expect(TextDecoration.strikethrough()).toBe('strikethrough');
     expect(TextDecoration.underline()).toBe('underline');
 
-    expect(ColorSpace.noCMYK()).toBe('no_cmyk');
-    expect(ColorSpace.SRGB()).toBe('srgb');
+    expect(ColorSpace.noCmyk()).toBe('no_cmyk');
+    expect(ColorSpace.srgb()).toBe('srgb');
     expect(ColorSpace.trueColor()).toBe('srgb:truecolor');
-    expect(ColorSpace.tinySRGB()).toBe('tinysrgb');
-    expect(ColorSpace.keepCMYK()).toBe('keep_cmyk');
-    expect(ColorSpace.CMYK()).toBe('cmyk');
+    expect(ColorSpace.tinySrgb()).toBe('tinysrgb');
+    expect(ColorSpace.keepCmyk()).toBe('keep_cmyk');
+    expect(ColorSpace.cmyk()).toBe('cmyk');
 
 
     expect(StreamingProfile.fullHd()).toBe('full_hd');

--- a/src/actions/adjust/ReplaceColorAction.ts
+++ b/src/actions/adjust/ReplaceColorAction.ts
@@ -1,6 +1,7 @@
 import {Action} from "../../internal/Action";
 import {QualifierValue} from "../../internal/qualifier/QualifierValue";
 import {Qualifier} from "../../internal/qualifier/Qualifier";
+import {prepareColor} from "../../internal/utils/prepareColor";
 
 /**
  * @description
@@ -49,7 +50,7 @@ class ReplaceColorAction extends Action {
 
   protected prepareQualifiers(): this {
     // e_replace_color:red:30:blue
-    const qualifierValue = new QualifierValue(['replace_color', this.targetColor, this.toleranceLevel, this.baseColor]);
+    const qualifierValue = new QualifierValue(['replace_color', this.targetColor, this.toleranceLevel, prepareColor(this.baseColor)]);
     this.addQualifier(new Qualifier('e', qualifierValue));
     return this;
   }

--- a/src/actions/effect.ts
+++ b/src/actions/effect.ts
@@ -19,6 +19,8 @@ import {DitherEffectAction} from "./effect/dither";
 import {DeshakeEffectAction} from "./effect/leveled/deshake";
 import {Pixelate} from "./effect/pixelate/pixelate";
 import {ImageSource} from "../values/source/sourceTypes/ImageSource";
+import {EffectActionWithStrength} from "./effect/EffectActions/EffectActionWithStrength";
+import {BlackwhiteEffectAction} from "./effect/leveled/blackwhite";
 
 
 /**
@@ -82,8 +84,8 @@ function colorize(colorizeLevel?: number):ColorizeEffectAction {
  * @param {number} oilPaintLevel The strength of the effect. (Range: 0 to 100, Server default: 30)
  * @return {EffectActionWithLevel}
  */
-function oilPaint(oilPaintLevel?: number):EffectActionWithLevel {
-  return new EffectActionWithLevel('oil_paint', oilPaintLevel);
+function oilPaint(oilPaintLevel?: number):EffectActionWithStrength {
+  return new EffectActionWithStrength('oil_paint', oilPaintLevel);
 }
 
 /**
@@ -161,8 +163,8 @@ function advancedRedEye():SimpleEffectAction {
  * @param {number | string} level The balance between black (100) and white (0). (Range: 0 to 100, Server default: 50)
  * @return EffectActionWithLevel
  */
-function blackwhite(level?: number | 'bw'):EffectActionWithLevel {
-  return new EffectActionWithLevel('blackwhite', level);
+function blackwhite(level?: number | 'bw'):BlackwhiteEffectAction {
+  return new BlackwhiteEffectAction('blackwhite', level);
 }
 
 

--- a/src/actions/effect.ts
+++ b/src/actions/effect.ts
@@ -379,11 +379,11 @@ function transition():SimpleEffectAction {
 /**
  * @description Applies a pixelatering filter to the asset.
  * @memberOf Actions.Effect
- * @param {number} pixelateLevel The pixelWidth of the pixelate. (Range: 1 to 2000, Server default: 100)
+ * @param {number} squareSize The squareSize in the pixelation. (Range: 1 to 2000, Server default: 100)
  * @return {Pixelate}
  */
-function pixelate(pixelateLevel?: number): Pixelate {
-  return new Pixelate(pixelateLevel);
+function pixelate(squareSize?: number): Pixelate {
+  return new Pixelate(squareSize);
 }
 
 

--- a/src/actions/effect.ts
+++ b/src/actions/effect.ts
@@ -82,7 +82,7 @@ function colorize(colorizeLevel?: number):ColorizeEffectAction {
  * @description Applies an oilPaint filter to the asset.
  * @memberOf Actions.Effect
  * @param {number} oilPaintLevel The strength of the effect. (Range: 0 to 100, Server default: 30)
- * @return {EffectActionWithLevel}
+ * @return {EffectActionWithStrength}
  */
 function oilPaint(oilPaintLevel?: number):EffectActionWithStrength {
   return new EffectActionWithStrength('oil_paint', oilPaintLevel);
@@ -161,7 +161,7 @@ function advancedRedEye():SimpleEffectAction {
  * @description Converts the image to black and white.
  * @memberOf Actions.Effect
  * @param {number | string} level The balance between black (100) and white (0). (Range: 0 to 100, Server default: 50)
- * @return EffectActionWithLevel
+ * @return BlackwhiteEffectAction
  */
 function blackwhite(level?: number | 'bw'):BlackwhiteEffectAction {
   return new BlackwhiteEffectAction('blackwhite', level);

--- a/src/actions/effect/leveled/blackwhite.ts
+++ b/src/actions/effect/leveled/blackwhite.ts
@@ -1,0 +1,14 @@
+import {LeveledEffectAction} from "../EffectActions/LeveledEffectAction";
+
+/**
+ * @augments LeveledEffectAction
+ * @description Converts the image to black and white.
+ */
+class BlackwhiteEffectAction extends LeveledEffectAction {
+  threshold(value: number | string): this {
+    return this.setLevel(value);
+  }
+}
+
+
+export {BlackwhiteEffectAction};

--- a/src/actions/effect/leveled/fadeIn.ts
+++ b/src/actions/effect/leveled/fadeIn.ts
@@ -5,12 +5,12 @@ import {LeveledEffectAction} from "../EffectActions/LeveledEffectAction";
  * @augments LeveledEffectAction
  * @description Fade out at the end of the video, use the length() method to set the time in ms for the fade to occur. (Server default: 2000)
  */
-class FadeoutEffectAction extends LeveledEffectAction {
+class FadeInEffectAction extends LeveledEffectAction {
   // We can't use EffectActionWithLength because this `length` is reversing the sign
   duration(value: number | string): this {
-    return this.setLevel(-value);
+    return this.setLevel(value);
   }
 }
 
 
-export {FadeoutEffectAction};
+export {FadeInEffectAction};

--- a/src/actions/effect/leveled/loop.ts
+++ b/src/actions/effect/leveled/loop.ts
@@ -5,7 +5,7 @@ import {LeveledEffectAction} from "../EffectActions/LeveledEffectAction";
  * @description Delivers a video or animated GIF that contains additional loops of the video/GIF.
  */
 class LoopEffectAction extends LeveledEffectAction {
-  iterations(value: number | string): this {
+  additionalIterations(value: number | string): this {
     return this.setLevel(value);
   }
 }

--- a/src/actions/effect/pixelate/pixelate.ts
+++ b/src/actions/effect/pixelate/pixelate.ts
@@ -8,11 +8,11 @@ import {Action} from "../../../internal/Action";
  */
 class Pixelate extends Action {
   private _region?: NamedRegion;
-  private _pixelWidth: number | string;
+  private _squareSize: number | string;
 
-  constructor(pixelWidth: number | string) {
+  constructor(squareSize: number | string) {
     super();
-    this._pixelWidth = pixelWidth;
+    this._squareSize = squareSize;
   }
 
   /**
@@ -26,10 +26,10 @@ class Pixelate extends Action {
 
   /**
    * @doc
-   * @param {number | string} pixelWidth The width of the pixel
+   * @param {number | string} squareSize The width of the pixel
    */
-  pixelWidth(pixelWidth: number | string): this {
-    this._pixelWidth = pixelWidth;
+  squareSize(squareSize: number | string): this {
+    this._squareSize = squareSize;
     return this;
   }
 
@@ -53,7 +53,7 @@ class Pixelate extends Action {
      * We're not using the full Gravity Qualifier here to prevent the code import for such a simplistic case
      */
 
-    const str = this._pixelWidth ? `:${this._pixelWidth}` : '';
+    const str = this._squareSize ? `:${this._squareSize}` : '';
     if ('_region' in this) {
       const qualifiers = this._region.qualifiers;
       // Copy qualifiers from the region "action" to the pixelate action

--- a/src/actions/roundCorners/RoundCornersAction.ts
+++ b/src/actions/roundCorners/RoundCornersAction.ts
@@ -21,10 +21,11 @@ class RoundCornersAction extends Action {
   radius(a:number, b?:number, c?:number, d?:number):this {
     const qualifierValue = new QualifierValue();
 
-    a && qualifierValue.addValue(a);
-    b && qualifierValue.addValue(b);
-    c && qualifierValue.addValue(c);
-    d && qualifierValue.addValue(d);
+    // In case a === 0, check typeof
+    typeof a !== undefined && qualifierValue.addValue(a);
+    typeof b !== undefined && qualifierValue.addValue(b);
+    typeof c !== undefined && qualifierValue.addValue(c);
+    typeof d !== undefined && qualifierValue.addValue(d);
 
     this.addQualifier(new Qualifier('r').addValue(qualifierValue));
     return this;

--- a/src/actions/videoEdit/TrimAction.ts
+++ b/src/actions/videoEdit/TrimAction.ts
@@ -11,6 +11,17 @@ class TrimAction extends Action {
   }
 
   /**
+   *
+   * @description Support Percentages in values (30% -> 30p)
+   * @param {string|number} val
+   * @private
+   * @return {string}
+   */
+  private parseVal(val: string|number): string | number {
+    return typeof val === 'number' ? val : val.replace('%', 'p');
+  }
+
+  /**
    * @description Sets the starting position of the part of the video to keep when trimming videos.
    *
    * @param {string|number} offset The starting position of the part of the video to keep. This can be specified as a
@@ -19,7 +30,7 @@ class TrimAction extends Action {
    * @return {this}
    */
   startOffset(offset: string|number): this {
-    return this.addQualifier(new Qualifier('so', offset));
+    return this.addQualifier(new Qualifier('so', this.parseVal(offset)));
   }
 
   /**
@@ -31,7 +42,7 @@ class TrimAction extends Action {
    * @return {this}
    */
   endOffset(offset: string|number): this {
-    return this.addQualifier(new Qualifier('eo', offset));
+    return this.addQualifier(new Qualifier('eo', this.parseVal(offset)));
   }
 
   /**
@@ -43,7 +54,7 @@ class TrimAction extends Action {
    * @return {this}
    */
   duration(duration: string|number): this {
-    return this.addQualifier(new Qualifier('du', duration));
+    return this.addQualifier(new Qualifier('du', this.parseVal(duration)));
   }
 }
 

--- a/src/internal/utils/prepareColor.ts
+++ b/src/internal/utils/prepareColor.ts
@@ -7,5 +7,9 @@ import {SystemColors} from "../../values/color";
  * @param color
  */
 export function prepareColor(color: SystemColors): SystemColors {
-  return color.match(/^#/) ? `rgb:${color.substr(1)}` : color;
+  if (color) {
+    return color.match(/^#/) ? `rgb:${color.substr(1)}` : color;
+  } else {
+    return color;
+  }
 }

--- a/src/values/colorSpace.ts
+++ b/src/values/colorSpace.ts
@@ -8,7 +8,7 @@
  * @@doc
  * @memberOf Values.ColorSpace
  */
-function SRGB(): string {
+function srgb(): string {
   return 'srgb';
 }
 
@@ -25,7 +25,7 @@ function trueColor(): string {
  * @@doc
  * @memberOf Values.ColorSpace
  */
-function tinySRGB(): string {
+function tinySrgb(): string {
   return 'tinysrgb';
 }
 
@@ -34,7 +34,7 @@ function tinySRGB(): string {
  * @@doc
  * @memberOf Values.ColorSpace
  */
-function CMYK(): string {
+function cmyk(): string {
   return 'cmyk';
 }
 
@@ -43,7 +43,7 @@ function CMYK(): string {
  * @@doc
  * @memberOf Values.ColorSpace
  */
-function noCMYK(): string {
+function noCmyk(): string {
   return 'no_cmyk';
 }
 
@@ -52,26 +52,26 @@ function noCMYK(): string {
  * @@doc
  * @memberOf Values.ColorSpace
  */
-function keepCMYK(): string {
+function keepCmyk(): string {
   return 'keep_cmyk';
 }
 
 const ColorSpace = {
-  CMYK,
-  keepCMYK,
-  noCMYK,
-  SRGB,
-  tinySRGB,
+  cmyk,
+  keepCmyk,
+  noCmyk,
+  srgb,
+  tinySrgb,
   trueColor
 };
 
 export {
   ColorSpace,
-  CMYK,
-  keepCMYK,
-  noCMYK,
-  SRGB,
-  tinySRGB,
+  cmyk,
+  keepCmyk,
+  noCmyk,
+  srgb,
+  tinySrgb,
   trueColor
 };
 

--- a/src/values/source/sourceTypes/TextSource.ts
+++ b/src/values/source/sourceTypes/TextSource.ts
@@ -4,6 +4,7 @@ import {TextStyle} from "../../textStyle";
 import {serializeCloudinaryCharacters} from "../../../internal/utils/serializeCloudinaryCharacters";
 import {Action} from "../../../internal/Action";
 import {Qualifier} from "../../../internal/qualifier/Qualifier";
+import {prepareColor} from "../../../internal/utils/prepareColor";
 
 /**
  * @memberOf Values.Source
@@ -51,7 +52,7 @@ class TextSource extends BaseSource {
     const tmpAction = new Action();
 
     tmpAction.addQualifier(new Qualifier(layerType, layerParam));
-    this._textColor && tmpAction.addQualifier(new Qualifier('co', this._textColor));
+    this._textColor && tmpAction.addQualifier(new Qualifier('co', prepareColor(this._textColor)));
     this._backgroundColor && tmpAction.addQualifier(new Qualifier('b', this._backgroundColor));
 
     return tmpAction.toString();


### PR DESCRIPTION
### Pull request for @Cloudinary/Base


#### What does this PR solve?
Various alignments to the code generator

- Change case (CMYK to cmyk)
- Add safety checks to prepareColor if color is not passed
- Change pixelWidth to squareSize for pixelate
- add tests(and support) for roundCorners radius with value 0
- Add prepareColor to text and subtitle layers' colors
- Add an explicit test for the base64 encoding for remote functions


#### Final checklist
- [X] Implementation is aligned to Spec.
- [X] Tests - Add proper tests to the added code
