### PR TITLE
Add support for raw action and transformation

### DIFF
--- a/__TESTS__/unit/actions/Conditional.test.ts
+++ b/__TESTS__/unit/actions/Conditional.test.ts
@@ -7,7 +7,7 @@ import {Resize} from "../../../src/actions/resize";
 describe('Tests for Transformation Action -- Conditional', () => {
   it('Creates a conditional transformation', () => {
     const tx = createNewImage().conditional(
-      Conditional.ifCondition('ar >= 1.0', new Transformation().addRawAction('w_100'))
+      Conditional.ifCondition('ar >= 1.0', new Transformation().addAction('w_100'))
     ).toString();
     // Ensures it compiles and doesn't throw
     expect(tx).toEqual('if_ar_gte_1.0/w_100/if_end');

--- a/__TESTS__/unit/transformation/transformation.test.ts
+++ b/__TESTS__/unit/transformation/transformation.test.ts
@@ -1,0 +1,17 @@
+import {Transformation} from "../../../src/transformation/Transformation";
+
+describe('Tests for ImageTransformation', () => {
+  let tx: Transformation = null;
+  beforeEach(() => {
+    tx = new Transformation();
+  });
+
+  it('Instantiates a ImageTransformation', () => {
+    expect(tx).toBeDefined();
+  });
+
+  it('Accepts a raw transformation', () => {
+    tx.addTransformation('w_100/w_200/w_300');
+    expect(tx.toString()).toContain('w_100/w_200/w_300');
+  });
+});

--- a/src/actions/videoEdit/ConcatenateAction.ts
+++ b/src/actions/videoEdit/ConcatenateAction.ts
@@ -118,7 +118,7 @@ class ConcatenateAction extends Action {
     }
 
     if (this._transition) {
-      concatSourceTx.addRawAction(this.getTransitionString());
+      concatSourceTx.addTransformation(this.getTransitionString());
     }
 
     // Put it all together, the transition is already part of the concatSourceTx

--- a/src/assets/CloudinaryTransformable.ts
+++ b/src/assets/CloudinaryTransformable.ts
@@ -215,10 +215,10 @@ class CloudinaryTransformable extends CloudinaryFile {
 
   /**
    * @desc A proxy to {@link SDK.Transformation| Transformation} - Calls the same method contains in this.transformation
-   * @param {SDK.Action} action
+   * @param {SDK.Action | string} action
    * @return {this}
    */
-  addAction(action: Action): this {
+  addAction(action: Action | string): this {
     this.transformation.addAction(action);
     return this;
   }

--- a/src/transformation/Transformation.ts
+++ b/src/transformation/Transformation.ts
@@ -33,15 +33,27 @@ class Transformation {
   }
 
   /**
-   * @param {Action} action
+   * @param {SDK.Action | string} action
+   * @return {this}
    */
-  addAction(action: Action): this {
+  addAction(action: Action | string): this {
+    if (typeof action === 'string') {
+      if (action.indexOf('/') >= 0) {
+        throw 'addAction cannot accept a string with a forward slash in it - /, use .addTransformation() instead';
+      }
+    }
     this.actions.push(action);
     return this;
   }
 
-  addRawAction(raw: string): this {
-    this.actions.push(raw);
+  /**
+   * @description Allows the injection of a raw transformation as a string into the transformation
+   * @param {string} stringTransformation
+   * @example transformation.addTransformation('w_100/w_200/w_300');
+   * @return {this}
+   */
+  addTransformation(stringTransformation: string): this {
+    this.actions.push(stringTransformation);
     return this;
   }
 


### PR DESCRIPTION
### Pull request for @Cloudinary/Base


#### What does this PR solve?
Add support for raw action and transformation
- When a string is passed to `addAction()`, validate it does not contain a forward slash
- When a string is passed to `addTransformation()`, perform no validation.


#### Final checklist
- [X] Implementation is aligned to Spec.
- [X] Tests - Add proper tests to the added code
