### PR TITLE
Flatten the Gravity qualifiers

### DIFF
--- a/__TESTS__/TestUtils/transformations/sampleFacePosition.ts
+++ b/__TESTS__/TestUtils/transformations/sampleFacePosition.ts
@@ -1,6 +1,6 @@
 import {Position} from "../../../src/values/position";
 import {Gravity} from "../../../src/values/gravity";
-import {FocusOn} from "../../../src/values/gravity/qualifiers/focusOn/FocusOn";
+import {FocusOn} from "../../../src/values/focusOn";
 
 /**
  * sample action used for testing

--- a/__TESTS__/unit/actions/Reshape.test.ts
+++ b/__TESTS__/unit/actions/Reshape.test.ts
@@ -3,7 +3,7 @@ import {scale} from "../../../src/actions/resize";
 import {Reshape} from "../../../src/actions/reshape";
 import {Position} from "../../../src/values/position";
 import {Gravity} from "../../../src/values/gravity";
-import {Compass} from "../../../src/values/gravity/qualifiers/compass/Compass";
+import {Compass} from "../../../src/values/compass";
 import {Transformation} from "../../../src/transformation/Transformation";
 import {createNewImage} from "../../TestUtils/createCloudinaryImage";
 

--- a/__TESTS__/unit/actions/Resize/ThumbAction.test.ts
+++ b/__TESTS__/unit/actions/Resize/ThumbAction.test.ts
@@ -1,6 +1,6 @@
 import getImageWithResize from "./shared/getImageWithResize";
 import {thumbnail} from "../../../../src/actions/resize";
-import {Compass} from "../../../../src/values/gravity/qualifiers/compass/Compass";
+import {Compass} from "../../../../src/values/compass";
 import {Gravity} from "../../../../src/values/gravity";
 
 describe('Tests for Transformation Action -- Resize.thumb()', () => {

--- a/__TESTS__/unit/types/Position.test.ts
+++ b/__TESTS__/unit/types/Position.test.ts
@@ -1,7 +1,7 @@
 import {Position} from "../../../src/values/position";
 import {Gravity} from "../../../src/values/gravity";
-import {Compass} from "../../../src/values/gravity/qualifiers/compass/Compass";
-import {FocusOn} from "../../../src/values/gravity/qualifiers/focusOn/FocusOn";
+import {Compass} from "../../../src/values/compass";
+import {FocusOn} from "../../../src/values/focusOn";
 
 
 describe('Position Qualifier', () => {

--- a/__TESTS__/unit/values/gravity/AutoGravity.test.ts
+++ b/__TESTS__/unit/values/gravity/AutoGravity.test.ts
@@ -1,6 +1,6 @@
 import {Gravity} from "../../../../src/values/gravity";
-import {AutoFocus} from "../../../../src/values/gravity/qualifiers/autoFocus/AutoFocus";
-import {FocusOn} from "../../../../src/values/gravity/qualifiers/focusOn/FocusOn";
+import {AutoFocus} from "../../../../src/values/autoFocus";
+import {FocusOn} from "../../../../src/values/focusOn";
 
 describe('Gravity Qualifier', () => {
   it('AutoGravity should return g_auto by default', () => {

--- a/__TESTS__/unit/values/gravity/CompassGravity.test.ts
+++ b/__TESTS__/unit/values/gravity/CompassGravity.test.ts
@@ -1,4 +1,4 @@
-import {Compass} from "../../../../src/values/gravity/qualifiers/compass/Compass";
+import {Compass} from "../../../../src/values/compass";
 import {Gravity} from "../../../../src/values/gravity";
 
 describe('Tests for Compass Gravity', () => {

--- a/__TESTS__/unit/values/gravity/FocusOnGravity.test.ts
+++ b/__TESTS__/unit/values/gravity/FocusOnGravity.test.ts
@@ -1,6 +1,6 @@
-import {FocusOn} from "../../../../src/values/gravity/qualifiers/focusOn/FocusOn";
+import {FocusOn} from "../../../../src/values/focusOn";
 import {Gravity} from "../../../../src/values/gravity";
-import {AutoFocus} from "../../../../src/values/gravity/qualifiers/autoFocus/AutoFocus";
+import {AutoFocus} from "../../../../src/values/autoFocus";
 
 describe('FocusOn Gravity Qualifier', () => {
   it('Expects focusOn to return {object}', () => {

--- a/src/values/autoFocus.ts
+++ b/src/values/autoFocus.ts
@@ -1,5 +1,5 @@
-import {QualifierValue} from "../../../../internal/qualifier/QualifierValue";
-import {FocusOnValue} from "../focusOn/FocusOn";
+import {QualifierValue} from "../internal/qualifier/QualifierValue";
+import {FocusOnValue} from "./focusOn";
 
 /**
  * @doc

--- a/src/values/compass.ts
+++ b/src/values/compass.ts
@@ -1,4 +1,4 @@
-import {CompassQualifier} from "./CompassQualifier";
+import {CompassQualifier} from "./gravity/qualifiers/compass/CompassQualifier";
 
 
 /**

--- a/src/values/focusOn.ts
+++ b/src/values/focusOn.ts
@@ -1,5 +1,4 @@
-import {FocusOnValue} from "./FocusOnValue";
-
+import {FocusOnValue} from "./gravity/qualifiers/focusOn/FocusOnValue";
 
 /**
  * @memberOf Values.FocusOns

--- a/src/values/gravity.ts
+++ b/src/values/gravity.ts
@@ -1,4 +1,4 @@
-import {FocusOnValue} from "./gravity/qualifiers/focusOn/FocusOn";
+import {FocusOnValue} from "./focusOn";
 import {OCR} from "./gravity/OCR/OCR";
 import {CompassGravity} from "./gravity/compassGravity/CompassGravity";
 import {FocusOnGravity} from "./gravity/focusOnGravity/FocusOnGravity";

--- a/src/values/gravity/GravityQualifier.ts
+++ b/src/values/gravity/GravityQualifier.ts
@@ -4,8 +4,8 @@ import {CompassGravity} from "./compassGravity/CompassGravity";
 import {AutoGravity} from "./autoGravity/AutoGravity";
 import {OCR} from "./OCR/OCR";
 import {FocusOnGravity} from "./focusOnGravity/FocusOnGravity";
-import {FocusOnValue} from "./qualifiers/focusOn/FocusOn";
-import {AutoFocus} from "./qualifiers/autoFocus/AutoFocus";
+import {FocusOnValue} from "../focusOn";
+import {AutoFocus} from "../autoFocus";
 import {CompassQualifier} from "./qualifiers/compass/CompassQualifier";
 import {XYCenterGravity} from "./xyCenterGravity/XYCenterGravity";
 

--- a/src/values/gravity/autoGravity/AutoGravity.ts
+++ b/src/values/gravity/autoGravity/AutoGravity.ts
@@ -1,4 +1,4 @@
-import {AutoFocus} from "../qualifiers/autoFocus/AutoFocus";
+import {AutoFocus} from "../../autoFocus";
 import {GravityQualifier} from "../GravityQualifier";
 
 /**

--- a/src/values/gravity/focusOnGravity/FocusOnGravity.ts
+++ b/src/values/gravity/focusOnGravity/FocusOnGravity.ts
@@ -1,4 +1,4 @@
-import {FocusOnValue} from "../qualifiers/focusOn/FocusOn";
+import {FocusOnValue} from "../../focusOn";
 import {GravityQualifier} from "../GravityQualifier";
 import {AutoGravity} from "../autoGravity/AutoGravity";
 


### PR DESCRIPTION
### Pull request for @Cloudinary/Base


#### What does this PR solve?
- Move all immediate qualifiers to the root of values
- Fix old import path (@cloudinary/base/values/gravity/qualifiers/focusOn/FocusOn) to be (cloudinary/base/values/focusOn)
- The same was done for AutoFocus and Compass


#### Final checklist
- [X] Implementation is aligned to Spec.
- [X] Tests - Add proper tests to the added code.
