### PR TITLE
Add the X,Y qualifiers to resize.limitFill by returning ResizeFillAction

### DIFF
--- a/__TESTS__/unit/actions/Resize/LimitFillAction.test.ts
+++ b/__TESTS__/unit/actions/Resize/LimitFillAction.test.ts
@@ -19,4 +19,17 @@ describe('Tests for Transformation Action -- Resize.limitFill', () => {
       'url');
     expect(url).toContain('ar_1.2,c_lfill,g_auto,h_250,w_250');
   });
+
+  it('Ensures it generates the right URL using xyGravity and x,y', () => {
+    const url = getImageWithResize(
+      limitFill()
+        .width(250)
+        .height(250)
+        .x(100)
+        .y(100)
+        .gravity(Gravity.xyCenter())
+        .aspectRatio(1.2),
+      'url');
+    expect(url).toContain('ar_1.2,c_lfill,g_xy_center,h_250,w_250,x_100,y_100');
+  });
 });

--- a/src/actions/resize.ts
+++ b/src/actions/resize.ts
@@ -124,10 +124,10 @@ function pad(width?: string|number, height?: string|number) :ResizePadAction<Com
  * @memberOf Actions.Resize
  * @param {number|string} width The required width of a transformed asset.
  * @param {number|string} height The required height of a transformed asset.
- * @return {LimitFillAction}
+ * @return {ResizeFillAction}
  */
-function limitFill(width?: string|number, height?: string|number) :ResizeAdvancedAction {
-  return new ResizeAdvancedAction('lfill', width, height);
+function limitFill(width?: string|number, height?: string|number) :ResizeFillAction {
+  return new ResizeFillAction('lfill', width, height);
 }
 
 


### PR DESCRIPTION
### Pull request for @Cloudinary/Base


#### What does this PR solve?
Add the X,Y qualifiers to resize.limitFill by returning ResizeFillAction


#### Final checklist
- [X] Implementation is aligned to Spec.
- [X] Tests - Add proper tests to the added code.
