### PR TITLE
Add relevant overlay tests from cloudinary-core

### DIFF
--- a/__TESTS__/unit/actions/Overlay.test.ts
+++ b/__TESTS__/unit/actions/Overlay.test.ts
@@ -219,7 +219,7 @@ describe('Tests for overlay actions', () => {
     expect(asset.toString()).toContain(`l_fetch:aHR0cHM6Ly9yZXMuY2xvdWRpbmFyeS5jb20vZGVtby9pbWFnZS91cGxvYWQvY2k=.png/${sampleTxResizePad().toString()}`);
   });
 
-  it("should serialize a text source", () => {
+  it.skip("should serialize a text source", () => {
     const asset = createNewImage();
     const text = 'Cloudinary for the win!';
     const textStyle = sampleTextStyle();
@@ -238,7 +238,7 @@ describe('Tests for overlay actions', () => {
     expect(actual).toBe(expected);
   });
 
-  it("should serialize a unicode url of fetch source", () => {
+  it.skip("should serialize a unicode url of fetch source", () => {
     const asset = createNewVideo();
     const REMOTE_URL = "https://upload.wikimedia.org/wikipedia/commons/2/2b/고창갯벌.jpg";
     const expected = "l_fetch:aHR0cHM6Ly91cGxvYWQud2lraW1lZGlhLm9yZy93aWtpcGVkaWEvY29tbW9ucy8yLzJiLyVFQSVCMyVBMCVFQyVCMCVCRCVFQSVCMCVBRiVFQiVCMiU4Qy5qcGc=/fl_layer_apply";
@@ -247,7 +247,7 @@ describe('Tests for overlay actions', () => {
     expect(actual).toBe(expected);
   });
 
-  it("should support string interpolation", () => {
+  it.skip("should support string interpolation", () => {
     const asset = createNewImage();
     const text = "$(start)Hello $(name)$(ext), $(no ) $( no)$(end)";
     const textStyle = sampleTextStyle();
@@ -257,7 +257,7 @@ describe('Tests for overlay actions', () => {
     expect(asset.toString()).toBe("l_text:Arial_18:$(start)Hello%20$(name)$(ext)%252C%20%24%28no%20%29%20%24%28%20no%29$(end)/fl_layer_apply");
   });
 
-  it("should throw an exception if fontFamily is not provided", () => {
+  it.skip("should throw an exception if fontFamily is not provided", () => {
     expect(() => new TextStyle(null, 17)).toThrow();
   });
 });

--- a/__TESTS__/unit/actions/Overlay.test.ts
+++ b/__TESTS__/unit/actions/Overlay.test.ts
@@ -218,4 +218,46 @@ describe('Tests for overlay actions', () => {
     // Explicitly check the resulting base64 string
     expect(asset.toString()).toContain(`l_fetch:aHR0cHM6Ly9yZXMuY2xvdWRpbmFyeS5jb20vZGVtby9pbWFnZS91cGxvYWQvY2k=.png/${sampleTxResizePad().toString()}`);
   });
+
+  it("should serialize a text source", () => {
+    const asset = createNewImage();
+    const text = 'Cloudinary for the win!';
+    const textStyle = sampleTextStyle();
+    const textSource = Source.text(text, textStyle);
+    asset.overlay(Overlay.source(textSource));
+
+    expect(asset.toString()).toBe("l_text:arial_50_bold_italic_strikethrough_justify_stroke_letter_spacing_10_line_spacing_20_letter_spacing_good_hinting_full:Cloudinary%20for%20the%20win%21'/fl_layer_apply");
+  });
+
+  it("should serialize a fetch source", () => {
+    const asset = createNewVideo();
+    const REMOTE_URL = 'http://res.cloudinary.com/demo/sample.jpg';
+    const expected = 'l_fetch:aHR0cDovL3Jlcy5jbG91ZGluYXJ5LmNvbS9kZW1vL3NhbXBsZS5qcGc=/fl_layer_apply';
+    const actual = asset.overlay(Overlay.source(Source.fetch(REMOTE_URL))).toString();
+
+    expect(actual).toBe(expected);
+  });
+
+  it("should serialize a unicode url of fetch source", () => {
+    const asset = createNewVideo();
+    const REMOTE_URL = "https://upload.wikimedia.org/wikipedia/commons/2/2b/고창갯벌.jpg";
+    const expected = "l_fetch:aHR0cHM6Ly91cGxvYWQud2lraW1lZGlhLm9yZy93aWtpcGVkaWEvY29tbW9ucy8yLzJiLyVFQSVCMyVBMCVFQyVCMCVCRCVFQSVCMCVBRiVFQiVCMiU4Qy5qcGc=/fl_layer_apply";
+    const actual = asset.overlay(Overlay.source(Source.fetch(REMOTE_URL))).toString();
+
+    expect(actual).toBe(expected);
+  });
+
+  it("should support string interpolation", () => {
+    const asset = createNewImage();
+    const text = "$(start)Hello $(name)$(ext), $(no ) $( no)$(end)";
+    const textStyle = sampleTextStyle();
+    const textSource = Source.text(text, textStyle);
+    asset.overlay(Overlay.source(textSource));
+
+    expect(asset.toString()).toBe("l_text:Arial_18:$(start)Hello%20$(name)$(ext)%252C%20%24%28no%20%29%20%24%28%20no%29$(end)/fl_layer_apply");
+  });
+
+  it("should throw an exception if fontFamily is not provided", () => {
+    expect(() => new TextStyle(null, 17)).toThrow();
+  });
 });

--- a/__TESTS__/unit/actions/Overlay.test.ts
+++ b/__TESTS__/unit/actions/Overlay.test.ts
@@ -254,7 +254,7 @@ describe('Tests for overlay actions', () => {
     const textSource = Source.text(text, textStyle);
     asset.overlay(Overlay.source(textSource));
 
-    expect(asset.toString()).toBe("l_text:Arial_18:$(start)Hello%20$(name)$(ext)%252C%20%24%28no%20%29%20%24%28%20no%29$(end)/fl_layer_apply");
+    expect(asset.toString()).toBe("l_text:arial_50_bold_italic_strikethrough_justify_stroke_letter_spacing_10_line_spacing_20_letter_spacing_good_hinting_full:$(start)Hello%20$(name)$(ext)%252C%20%24%28no%20%29%20%24%28%20no%29$(end)/fl_layer_apply");
   });
 
   it.skip("should throw an exception if fontFamily is not provided", () => {


### PR DESCRIPTION
Add relevant overlay tests from cloudinary-core:
Some of the added tests fail and so we should consider whether they are indeed needed or update the spec/implementation.
Failing tests:
1. 'should serialize a text source'
Not converting spaces to %20

2. 'should serialize a unicode url of fetch source'
Breaking on chinese characters

3. 'should support string interpolation'
This is also failing due to not converting spaces to %20

4. 'should throw an exception if fontFamily is not provided'
TextStyle(null, 17)