### PR TITLE
Breaking - change the name of the named export of the entire SDK

### DIFF
--- a/__TESTS_BUNDLE_SIZE__/bundleSizeTestCases.ts
+++ b/__TESTS_BUNDLE_SIZE__/bundleSizeTestCases.ts
@@ -76,7 +76,7 @@ const bundleSizeTestCases:ITestCase[] = [
     name: 'Import all of the SDK',
     sizeLimitInKB: 110,
     importsArray: [
-      importFromBase('CloudinarySDK')
+      importFromBase('CloudinaryBaseSDK')
     ]
   }
 ];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,7 +7,7 @@ export default [{
     {
       file: 'dist/bundles/umd/base.js',
       format: 'umd',
-      name:'cloudinaryBase'
+      name:'CloudinaryBaseSDK'
     }
   ],
   plugins: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,8 +12,7 @@ import {createCloudinaryV1URL} from "./backwards/createCloudinaryURL";
 /**
  * @namespace SDK
  */
-
-const CloudinarySDK = {
+const CloudinaryBaseSDK = {
   Transformation,
   ImageTransformation,
   VideoTransformation,
@@ -37,6 +36,6 @@ export {
   CloudinaryVideo,
   CloudinaryFile,
   createCloudinaryV1URL,
-  CloudinarySDK,
-  CloudinarySDK as default
+  CloudinaryBaseSDK,
+  CloudinaryBaseSDK as default
 };


### PR DESCRIPTION
### Pull request for @Cloudinary/Base


#### What does this PR solve?
Breaking - change the name of the named export of the entire SDK

Change from CloudinarySDK to CloudinaryBaseSDK, including the UMD change

