### PR TITLE
Add tests for `asset.setAssetType`

### DIFF
--- a/__TESTS__/unit/asset/CloudinaryFile.test.ts
+++ b/__TESTS__/unit/asset/CloudinaryFile.test.ts
@@ -1,6 +1,4 @@
 import {CloudinaryFile} from "../../../src/assets/CloudinaryFile";
-import {Underlay} from "../../../src/actions/underlay";
-import {Source} from "../../../src/qualifiers/source";
 
 describe('Tests for CloudinaryFile', () => {
   let cloudinaryFile: CloudinaryFile = null;
@@ -33,6 +31,12 @@ describe('Tests for CloudinaryFile', () => {
       .setVersion('12345');
 
     expect(cloudinaryFile.toURL()).toContain('video/fetch/v12345/sample');
+  });
+
+  it('should use assetType from the asset', () => {
+    cloudinaryFile.setAssetType('raw');
+
+    expect(cloudinaryFile.toURL()).toBe('https://res.cloudinary.com/demo/raw/upload/sample');
   });
 });
 

--- a/__TESTS__/unit/config/cloudinaryConfig.test.ts
+++ b/__TESTS__/unit/config/cloudinaryConfig.test.ts
@@ -155,6 +155,7 @@ describe('Tests for CloudinaryConfiguration', () => {
 
     expect(url).toContain('http://');
   });
+
   it('should allow overriding cloudName in config', () => {
     const conf = new CloudinaryConfig({
       cloud: {
@@ -170,11 +171,6 @@ describe('Tests for CloudinaryConfiguration', () => {
   });
 
   // These tests should be "translated" to js base code when these missing features are added:
-  it.skip('should use resource_type from options', () => {
-    test_cloudinary_url('test', {
-      resource_type: 'raw'
-    }, 'https://res.cloudinary.com/test123/raw/upload/test', {});
-  });
   it.skip('should put format after url_suffix', () => {
     test_cloudinary_url('test', {
       url_suffix: 'hello',


### PR DESCRIPTION
### Pull request for @Cloudinary/Base


#### What does this PR solve?
Add tests for asset.setAssetType function
Remove the function we copied from core and reimplemented it with the right syntax.

#### Final checklist
- [X] Implementation is aligned to Spec.
- [X] Tests - Add proper tests to the added code.
