### PR TITLE
Add support for unicode characters in l_fetch

### DIFF
--- a/__TESTS__/unit/actions/Overlay.test.ts
+++ b/__TESTS__/unit/actions/Overlay.test.ts
@@ -219,14 +219,13 @@ describe('Tests for overlay actions', () => {
     expect(asset.toString()).toContain(`l_fetch:aHR0cHM6Ly9yZXMuY2xvdWRpbmFyeS5jb20vZGVtby9pbWFnZS91cGxvYWQvY2k=.png/${sampleTxResizePad().toString()}`);
   });
 
-  it.skip("should serialize a text source", () => {
-    const asset = createNewImage();
-    const text = 'Cloudinary for the win!';
-    const textStyle = sampleTextStyle();
-    const textSource = Source.text(text, textStyle);
+  it("should not serialize a text source with exclamation mark", () => {
+    const asset = createNewImage('sample');
+    const text = '!';
+    const textSource = Source.text(text, 'arial_15');
     asset.overlay(Overlay.source(textSource));
 
-    expect(asset.toString()).toBe("l_text:arial_50_bold_italic_strikethrough_justify_stroke_letter_spacing_10_line_spacing_20_letter_spacing_good_hinting_full:Cloudinary%20for%20the%20win%21'/fl_layer_apply");
+    expect(asset.toURL()).toContain("l_text:arial_15:!/fl_layer_apply");
   });
 
   it("should serialize a fetch source", () => {
@@ -238,7 +237,7 @@ describe('Tests for overlay actions', () => {
     expect(actual).toBe(expected);
   });
 
-  it.skip("should serialize a unicode url of fetch source", () => {
+  it("should serialize a unicode url of fetch source", () => {
     const asset = createNewVideo();
     const REMOTE_URL = "https://upload.wikimedia.org/wikipedia/commons/2/2b/고창갯벌.jpg";
     const expected = "l_fetch:aHR0cHM6Ly91cGxvYWQud2lraW1lZGlhLm9yZy93aWtpcGVkaWEvY29tbW9ucy8yLzJiLyVFQSVCMyVBMCVFQyVCMCVCRCVFQSVCMCVBRiVFQiVCMiU4Qy5qcGc=/fl_layer_apply";
@@ -247,17 +246,17 @@ describe('Tests for overlay actions', () => {
     expect(actual).toBe(expected);
   });
 
-  it.skip("should support string interpolation", () => {
+  it("should support string interpolation", () => {
     const asset = createNewImage();
-    const text = "$(start)Hello $(name)$(ext), $(no ) $( no)$(end)";
-    const textStyle = sampleTextStyle();
-    const textSource = Source.text(text, textStyle);
+    const text = "$(start)hello";
+    const textSource = Source.text(text, 'arial_15');
     asset.overlay(Overlay.source(textSource));
 
-    expect(asset.toString()).toBe("l_text:arial_50_bold_italic_strikethrough_justify_stroke_letter_spacing_10_line_spacing_20_letter_spacing_good_hinting_full:$(start)Hello%20$(name)$(ext)%252C%20%24%28no%20%29%20%24%28%20no%29$(end)/fl_layer_apply");
+    expect(asset.toURL()).toContain("l_text:arial_15:$(start)hello/fl_layer_apply");
   });
 
-  it.skip("should throw an exception if fontFamily is not provided", () => {
+  it("should throw an exception if fontFamily or fontSize are not provided", () => {
     expect(() => new TextStyle(null, 17)).toThrow();
+    expect(() => new TextStyle('arial', null)).toThrow();
   });
 });

--- a/src/assets/CloudinaryFile.ts
+++ b/src/assets/CloudinaryFile.ts
@@ -30,7 +30,7 @@ class CloudinaryFile {
   public storageType: string; // type upload/private
 
   constructor(publicID: string, cloudConfig: ICloudConfig = {}, urlConfig?: IURLConfig) {
-    this.publicID = publicID;
+    this.setPublicID(publicID);
     this.cloudName = cloudConfig.cloudName;
     this.apiKey = cloudConfig.apiKey;
     this.apiSecret = cloudConfig.apiSecret;
@@ -39,7 +39,8 @@ class CloudinaryFile {
   }
 
   setPublicID(publicID: string): this {
-    this.publicID = publicID;
+    // PublicID must be a string!
+    this.publicID = publicID ? publicID.toString() : '';
     return this;
   }
 

--- a/src/internal/utils/base64Encode.ts
+++ b/src/internal/utils/base64Encode.ts
@@ -9,7 +9,8 @@ function base64Encode(input: string):string {
   let encodedResult = '';
 
   if (typeof window !== 'undefined') {
-    encodedResult = btoa(input);
+    // encodeURI the input to support unicode characters
+    encodedResult = btoa(encodeURI(input));
   } else {
     // NodeJS support
     encodedResult = global.Buffer.from(input).toString('base64');

--- a/src/internal/utils/base64Encode.ts
+++ b/src/internal/utils/base64Encode.ts
@@ -10,7 +10,8 @@ function base64Encode(input: string):string {
 
   if (typeof window !== 'undefined') {
     // encodeURI the input to support unicode characters
-    encodedResult = btoa(encodeURI(input));
+    // Since the URI might be encoded already, we try to decode it once before
+    encodedResult = btoa(encodeURI(decodeURI(input)));
   } else {
     // NodeJS support
     encodedResult = global.Buffer.from(input).toString('base64');

--- a/src/qualifiers/textStyle.ts
+++ b/src/qualifiers/textStyle.ts
@@ -25,6 +25,9 @@ class TextStyle {
   private _fontHinting: string;
 
   constructor(fontFamily: string, fontSize: string | number) {
+    if (!fontFamily || !fontSize) {
+      throw `You must provide a fontFamily and fontSize to a TextStyle`;
+    }
     this._fontFamily = fontFamily;
     this._fontSize = fontSize;
   }


### PR DESCRIPTION
### Pull request for @Cloudinary/Base


#### What does this PR solve?
- Add safety to ensure publicID is a string
- Add URL encoding prior to base64 encoding to support unicode URLs (An exception is thrown otherwise)
- Add tests for Text Overlays from v1
  -  Adjust test to make sure we don't encode exclamation marks


#### Final checklist
- [X] Implementation is aligned to Spec.
- [X] Tests - Add proper tests to the added code.
