### PR TITLE
Feature/implement missing url features

### DIFF
--- a/__TESTS__/TestUtils/createCloudinaryFile.ts
+++ b/__TESTS__/TestUtils/createCloudinaryFile.ts
@@ -1,0 +1,14 @@
+import ICloudConfig from "../../src/config/interfaces/Config/ICloudConfig";
+import IURLConfig from "../../src/config/interfaces/Config/IURLConfig";
+import {CloudinaryFile} from "../../src";
+
+/**
+ *
+ */
+function createNewFile(publicID?: string, cloudConfig?: ICloudConfig, urlConfig?:IURLConfig): CloudinaryFile {
+  return new CloudinaryFile(publicID, Object.assign({
+    cloudName: 'demo'
+  }, cloudConfig), urlConfig);
+}
+
+export {createNewFile};

--- a/__TESTS__/unit/actions/Overlay.test.ts
+++ b/__TESTS__/unit/actions/Overlay.test.ts
@@ -252,7 +252,7 @@ describe('Tests for overlay actions', () => {
     const textSource = Source.text(text, 'arial_15');
     asset.overlay(Overlay.source(textSource));
 
-    expect(asset.toURL()).toContain("l_text:arial_15:$(start)hello/fl_layer_apply");
+    expect(asset.toString()).toContain("l_text:arial_15:$(start)hello/fl_layer_apply");
   });
 
   it("should throw an exception if fontFamily or fontSize are not provided", () => {

--- a/__TESTS__/unit/asset/CloudinaryFile.test.ts
+++ b/__TESTS__/unit/asset/CloudinaryFile.test.ts
@@ -26,11 +26,11 @@ describe('Tests for CloudinaryFile', () => {
     cloudinaryFile
       .setPublicID('sample')
       .setSuffix('foo')
-      .setAssetType('video')
-      .setStorageType('fetch')
+      .setAssetType('image')
+      .setStorageType('private')
       .setVersion('12345');
 
-    expect(cloudinaryFile.toURL()).toContain('video/fetch/v12345/sample');
+    expect(cloudinaryFile.toURL()).toContain('private_images/v12345/sample/foo');
   });
 
   it('should use assetType from the asset', () => {

--- a/__TESTS__/unit/config/cloudinaryConfig.test.ts
+++ b/__TESTS__/unit/config/cloudinaryConfig.test.ts
@@ -2,10 +2,7 @@ import CloudinaryConfig from "../../../src/config/CloudinaryConfig";
 import URLConfig from "../../../src/config/URLConfig";
 import CloudConfig from "../../../src/config/CloudConfig";
 import {createNewImage} from "../../TestUtils/createCloudinaryImage";
-
-// Mocks to be removed after we have a well defined syntax for the missing features
-const test_cloudinary_url = (publicId:string, options:any, expected:any, optionsAfter:any) => {};
-const cl = {url:(publicId:string, options:any)=>{}};
+import {createNewFile} from "../../TestUtils/createCloudinaryFile";
 
 describe('Tests for CloudinaryConfiguration', () => {
   it('Creates a CloudinaryConfig with defaults', () => {
@@ -170,82 +167,63 @@ describe('Tests for CloudinaryConfiguration', () => {
     });
   });
 
-  // These tests should be "translated" to js base code when these missing features are added:
-  it.skip('should put format after url_suffix', () => {
-    test_cloudinary_url('test', {
-      url_suffix: 'hello',
-      private_cdn: true,
-      format: 'jpg'
-    }, 'https://test123-res.cloudinary.com/images/test/hello.jpg', {});
-  });
-  it.skip('should support url_suffix for raw uploads', () => {
-    test_cloudinary_url('test', {
-      url_suffix: 'hello',
-      private_cdn: true,
-      resource_type: 'raw'
-    }, 'https://test123-res.cloudinary.com/files/test/hello', {});
-  });
-  it.skip('should support url_suffix for raw uploads', () => {
-    test_cloudinary_url('test', {
-      url_suffix: 'hello',
-      private_cdn: true,
-      resource_type: 'image',
-      type: 'private'
-    }, 'https://test123-res.cloudinary.com/private_images/test/hello', {});
+  it('should put format after url_suffix', () => {
+    const img = createNewImage('sample', {
+      cloudName: 'demo'
+    }).setSuffix('SOME_SUFFIX');
+
+    expect(img.toURL()).toBe("https://res.cloudinary.com/demo/images/sample/SOME_SUFFIX");
   });
 
-  it.skip('should support root_path for private_cdn', () => {
-    test_cloudinary_url('test', {
-      use_root_path: true,
-      private_cdn: true
-    }, 'https://test123-res.cloudinary.com/test', {});
-    test_cloudinary_url('test', {
-      use_root_path: true,
-      angle: 0,
-      private_cdn: true
-    }, 'https://test123-res.cloudinary.com/a_0/test', {});
+  it('should support url_suffix for raw uploads', () => {
+    const file = createNewFile('sample', {
+      cloudName: 'demo'
+    }).setSuffix('SOME_SUFFIX');
+
+    expect(file.toURL()).toBe("https://res.cloudinary.com/demo/images/sample/SOME_SUFFIX");
   });
-  it.skip('should support globally set use_root_path for private_cdn', () => {
-    test_cloudinary_url('test', {
-      private_cdn: true,
-      use_root_path: true
-    }, 'https://test123-res.cloudinary.com/test', {});
+
+  it('should support url_suffix for private uploads', () => {
+    const img = createNewImage('sample');
+    img.setStorageType('private');
+    img.setSuffix('SOME_SUFFIX');
+
+    expect(img.toURL()).toBe("https://res.cloudinary.com/demo/private_images/sample/SOME_SUFFIX");
   });
-  it.skip('should support use_root_path together with url_suffix for private_cdn', () => {
-    test_cloudinary_url('test', {
-      use_root_path: true,
-      private_cdn: true,
-      url_suffix: 'hello'
-    }, 'https://test123-res.cloudinary.com/test/hello', {});
+
+  it('should support useRootPath with privateCdn', () => {
+    const img = createNewImage('sample', {}, {
+      useRootPath: true,
+      privateCdn: true
+    });
+
+    expect(img.toURL()).toBe("https://demo-res.cloudinary.com/sample");
   });
-  it.skip('should disallow use_root_path if not image/upload', () => {
+
+  it('should support `useRootPath` together with `suffix` for `privateCdn`', () => {
+    const img = createNewImage('sample', {}, {
+      useRootPath: true,
+      privateCdn: true
+    }).setSuffix('SOME_SUFFIX');
+
+    expect(img.toURL()).toBe("https://demo-res.cloudinary.com/sample/SOME_SUFFIX");
+  });
+
+  it('should disallow useRootPath if not image/upload', () => {
     expect(() => {
-      cl.url('test', {
-        use_root_path: true,
-        private_cdn: true,
-        type: 'facebook'
-      });
+      const img = createNewImage('sample', {}, {
+        useRootPath: true,
+        privateCdn: true
+      }).setStorageType('private');
+      img.toURL();
     }).toThrow();
+
     expect(() => {
-      cl.url('test', {
-        use_root_path: true,
-        private_cdn: true,
-        resource_type: 'raw'
-      });
+      const img = createNewImage('sample', {}, {
+        useRootPath: true,
+        privateCdn: true
+      }).setAssetType('raw');
+      img.toURL();
     }).toThrow();
-  });
-  it.skip('should generate sprite css urls', () => {
-    let result;
-    //result = cl.sprite_css('test');
-    expect(result).toEqual('https://res.cloudinary.com/test123/image/sprite/test.css');
-    //result = cl.sprite_css('test.css');
-    expect(result).toEqual('https://res.cloudinary.com/test123/image/sprite/test.css');
-  });
-  it.skip('should allow to override protocol', () => {
-    const options = {
-      'protocol': 'custom:'
-    };
-    const result = cl.url('test', options);
-    expect(result).toEqual('custom://res.cloudinary.com/test123/image/upload/test');
   });
 });

--- a/src/assets/CloudinaryFile.ts
+++ b/src/assets/CloudinaryFile.ts
@@ -11,6 +11,19 @@ import IAuthTokenConfig from "../config/interfaces/Config/IAuthTokenConfig";
 import URLConfig from "../config/URLConfig";
 
 /**
+ * This const contains all the valid combination of asset/storage for URL shortening purposes
+ * It's exported because it's used in a test, but it's not really shared enough to belong in a separate file
+ */
+export const SEO_TYPES: Record<string, string> = {
+  "image/upload": "images",
+  "image/private": "private_images",
+  "image/authenticated": "authenticated_images",
+  "raw/upload": "files",
+  "video/upload": "videos"
+};
+
+
+/**
  * @desc Cloudinary file without a transformation
  * @summary SDK
  * @memberOf SDK
@@ -54,6 +67,11 @@ class CloudinaryFile {
     return this;
   }
 
+  setSignature(signature: string): this {
+    this.signature = signature;
+    return this;
+  }
+
   setVersion(newVersion: number | string): this {
     if (newVersion) {
       this.version = newVersion;
@@ -78,20 +96,94 @@ class CloudinaryFile {
 
 
   /**
-   *
-   * @description Creates a fully qualified CloudinaryURL
-   * @return {string} CloudinaryURL
+   * @description Validate various options before attempting to create a URL
+   * The function will throw in case a violation
+   * @throws Validation errors
    */
-  createCloudinaryURL(transformation?: Transformation | string): string {
+  validateAssetForURLCreation(): void {
     if (typeof this.cloudName === 'undefined') {
       throw 'You must supply a cloudName in either toURL() or when initializing the asset';
     }
-    const prefix = getUrlPrefix(this.cloudName, this.urlConfig);
+
+    const suffixContainsDot = this.suffix && this.suffix.indexOf('.') >= 0;
+    const suffixContainsSlash = this.suffix && this.suffix.indexOf('/') >= 0;
+
+    if (suffixContainsDot || suffixContainsSlash) {
+      throw '`suffix`` should not include . or /';
+    }
+  }
+
+
+
+  /**
+   * @description return an SEO friendly name for a combination of asset/storage, some examples:
+   * * image/upload -> images
+   * * video/upload -> videos
+   * If no match is found, return `{asset}/{storage}`
+   */
+  getResourceType(): string {
     const assetType = handleAssetType(this.assetType);
     const storageType = handleStorageType(this.storageType);
 
-    const transformationString = transformation ? transformation.toString() : '';
+    const hasSuffix = !!this.suffix;
+    const regularSEOType = `${assetType}/${storageType}`;
+    const shortSEOType = SEO_TYPES[`${assetType}/${storageType}`];
+    const useRootPath = this.urlConfig.useRootPath;
+    const shorten = this.urlConfig.shorten;
 
+    // Quick exit incase of useRootPath
+    if (useRootPath) {
+      if (regularSEOType === 'image/upload') {
+        return ''; // For image/upload we're done, just return nothing
+      } else {
+        throw new Error(`useRootPath can only be used with assetType: 'image' and storageType: 'upload'. Provided: ${regularSEOType} instead`);
+      }
+    }
+
+    if (shorten && regularSEOType === 'image/upload') {
+      return 'iu';
+    }
+
+
+    if (hasSuffix) {
+      if (shortSEOType) {
+        return shortSEOType;
+      } else {
+        throw new Error(`URL Suffix only supported for ${Object.keys(SEO_TYPES).join(', ')}, Provided: ${regularSEOType} instead`);
+      }
+    }
+
+    // If all else fails, return the regular image/upload combination (asset/storage)
+    return regularSEOType;
+  }
+
+
+  getSignature() {
+    if (this.signature) {
+      return `s--${this.signature}--`;
+    } else {
+      return '';
+    }
+  }
+
+  /**
+   *
+   * @description Creates a fully qualified CloudinaryURL
+   * @return {string} CloudinaryURL
+   * @throws Validation Errors
+   */
+  createCloudinaryURL(transformation?: Transformation | string): string {
+    // In accordance with the existing implementation, if no publicID exists we should return nothing.
+    if (!this.publicID) {
+      return '';
+    }
+
+    // Throws if some options are mis-configured
+    // See the function for more information on when it throws
+    this.validateAssetForURLCreation();
+
+    const prefix = getUrlPrefix(this.cloudName, this.urlConfig);
+    const transformationString = transformation ? transformation.toString() : '';
     const version = getUrlVersion(this.publicID, this.version, this.urlConfig.forceVersion);
 
     const publicID = this.publicID
@@ -99,7 +191,9 @@ class CloudinaryFile {
       // we can't use serializeCloudinaryCharacters because that does both things (, and /)
       .replace(/,/g, '%2C');
 
-    const url = [prefix, assetType, storageType, transformationString, version, publicID]
+    // Resource type is a mixture of assetType, storageType and various URL Configurations
+    // Note how `suffix` changes both image/upload (resourceType) and also is appended at the end
+    const url = [prefix, this.getResourceType(), this.getSignature(), transformationString, version, publicID, this.suffix]
       .filter((a) => a)
       .join('/');
 

--- a/src/assets/CloudinaryFile.ts
+++ b/src/assets/CloudinaryFile.ts
@@ -39,6 +39,7 @@ class CloudinaryFile {
   public version: number | string;
   public publicID: string;
   public extension: string;
+  public signature: string;
   public suffix: string;
   public storageType: string; // type upload/private
 


### PR DESCRIPTION
### Pull request for @Cloudinary/Base


#### What does this PR solve?
This PR adds some missing configuration features into this project

- `URL Suffix`
- `URL Shorten`
- `useRootPath`
- SEO Shortening (image/upload -> iu)

This PR also adds various validations from `v1` such as:
- calling `toURL()` with missing publicID will return an empty string
- Suffix can only be used with specific asset/storage types
- useRootPath can only be used with image/upload


This PR is split into meaningful (Chronological) commits: 

1.  [Add a Test Utility function](https://github.com/cloudinary/cloudinary-js-base/commit/1c19364)
2. [Add missing URL Tests and configurations](https://github.com/cloudinary/cloudinary-js-base/commit/7e6cf4f)
3. [Out of scope refactoring](https://github.com/cloudinary/cloudinary-js-base/commit/4b5db5e) - Needed due to changes in the implementation
4. [Missig public property](https://github.com/cloudinary/cloudinary-js-base/commit/e76492e) - Small fix that adds a public property to an asset


#### Final checklist
- [X] Implementation is aligned to Spec.
- [X] Tests - Add proper tests to the added code.
