### PR TITLE
Fix indentation issues in the code examples in the reference website

### DIFF
--- a/__DOCS__/JSDocTemplate/src/tmpl/tag/_example.hbs
+++ b/__DOCS__/JSDocTemplate/src/tmpl/tag/_example.hbs
@@ -5,7 +5,8 @@
 		<div class="example-caption">{{{caption}}}</div>
 		{{/if}}
 		<div class="example-code">
-			<pre class="prettyprint source language-{{lang}}"><code class="language-{{lang}}">{{code}}</code></pre>
+<pre class="prettyprint source language-{{lang}}"><code class="language-{{lang}}">
+{{code}}</code></pre> <!-- Indentation for the code examples! -->
 		</div>
 		{{#if run}}
 		<p class="example-run">

--- a/__DOCS__/JSDocTemplate/template/tmpl.js
+++ b/__DOCS__/JSDocTemplate/template/tmpl.js
@@ -756,13 +756,13 @@ Handlebars.registerPartial("tag/example", this["tmpl"]["tag/example"] = Handleba
     var stack1, helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
   return ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.caption : depth0),{"name":"if","hash":{},"fn":container.program(4, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
-    + "		<div class=\"example-code\">\r\n			<pre class=\"prettyprint source language-"
+    + "		<div class=\"example-code\">\r\n<pre class=\"prettyprint source language-"
     + alias4(((helper = (helper = helpers.lang || (depth0 != null ? depth0.lang : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"lang","hash":{},"data":data}) : helper)))
     + "\"><code class=\"language-"
     + alias4(((helper = (helper = helpers.lang || (depth0 != null ? depth0.lang : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"lang","hash":{},"data":data}) : helper)))
-    + "\">"
+    + "\">\r\n"
     + alias4(((helper = (helper = helpers.code || (depth0 != null ? depth0.code : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"code","hash":{},"data":data}) : helper)))
-    + "</code></pre>\r\n		</div>\r\n"
+    + "</code></pre> <!-- Indentation for the code examples! -->\r\n		</div>\r\n"
     + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.run : depth0),{"name":"if","hash":{},"fn":container.program(6, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "");
 },"4":function(container,depth0,helpers,partials,data) {
     var stack1, helper;

--- a/src/actions/rotate/RotateAction.ts
+++ b/src/actions/rotate/RotateAction.ts
@@ -21,7 +21,7 @@ class RotateAction extends Action {
   /**
    * @description Rotates an asset using a defined mode.
    * @param {Qualifiers.RotationMode | string} rotationMode
-   * For a list of supported rotation modes see {@link Qualifiers.rotationModeValues| types of rotation modes} for
+   * For a list of supported rotation modes see {@link Qualifiers.RotationMode| types of rotation modes} for
    * possible values
    * @return {this}
    */

--- a/src/actions/rotate/mode.ts
+++ b/src/actions/rotate/mode.ts
@@ -6,7 +6,7 @@ import {RotationModeQualifierValue} from "../../qualifiers/rotate/RotationModeQu
  * @memberOf Actions.Rotate
  * @description Rotate an image by using a rotationMode
  * @param {string} rotationMode
- * For a list of supported rotation modes see {@link Qualifiers.rotationModeValues| types of rotation modes} for
+ * For a list of supported rotation modes see {@link Qualifiers.RotationMode| types of rotation modes} for
  * possible values
  * @example
  * import {mode} from "@cloudinary/base/actions/rotate";

--- a/src/qualifiers/rotationMode.ts
+++ b/src/qualifiers/rotationMode.ts
@@ -1,8 +1,8 @@
 
 /**
  * @description Contains functions to select the rotation mode.
- * <b>Learn more</b>: {@link https://cloudinary.com/documentation/image_transformations#rotating_images | Rotating images}
- * <b>Learn more</b>: {@link https://cloudinary.com/documentation/video_manipulation_and_delivery#rotating_videos | Rotating videos}
+ * </br><b>Learn more</b>: {@link https://cloudinary.com/documentation/image_transformations#rotating_images | Rotating images}
+ * </br><b>Learn more</b>: {@link https://cloudinary.com/documentation/video_manipulation_and_delivery#rotating_videos | Rotating videos}
  * @memberOf Qualifiers
  * @namespace RotationMode
  */


### PR DESCRIPTION
### Pull request for @Cloudinary/Base


#### What does this PR solve?
Fix indentation issues in the code examples in the reference website
Also fix a minor typo in one of the types

### Before 
<img width="400" alt="Screen Shot 2021-04-04 at 19 20 06" src="https://user-images.githubusercontent.com/59408474/113515050-c6df3e00-957a-11eb-80c1-3bc7f8c2a15a.png">


### after
<img width="400" alt="Screen Shot 2021-04-04 at 19 18 43" src="https://user-images.githubusercontent.com/59408474/113515042-b4fd9b00-957a-11eb-9c28-05ca952dd8c1.png">