### PR TITLE
Add new setters to variable: float, integer and string

### DIFF
--- a/__TESTS__/unit/actions/Variable.test.ts
+++ b/__TESTS__/unit/actions/Variable.test.ts
@@ -1,5 +1,5 @@
 import {createNewImage} from "../../TestUtils/createCloudinaryImage";
-import {Variable} from "../../../src/actions/variable";
+import {setFloat, setInteger, setString, Variable} from "../../../src/actions/variable";
 import {Expression} from "../../../src/qualifiers/expression";
 
 const {set} = Variable;
@@ -10,6 +10,29 @@ describe('Tests for Transformation Action -- Variable', () => {
   it('tests common variable values', () => {
     expect(set('a', 30).toString()).toBe('$a_30');
     expect(set('a', '30').toString()).toBe('$a_!30!');
+  });
+
+  it('tests setFloat with common variable values', () => {
+    expect(setFloat('a', -1).toString()).toBe(`$a_-1.0`);
+    expect(setFloat('a', 0).toString()).toBe(`$a_0.0`);
+    expect(setFloat('a', 1).toString()).toBe(`$a_1.0`);
+    expect(setFloat('a', 0.01).toString()).toBe(`$a_0.01`);
+  });
+
+  it('tests setInteger with common variable values', () => {
+    expect(setInteger('a', -1).toString()).toBe(`$a_-1`);
+    expect(setInteger('a', 0).toString()).toBe(`$a_0`);
+    expect(setInteger('a', 0.9).toString()).toBe(`$a_1`);
+    expect(setInteger('a', 1).toString()).toBe(`$a_1`);
+    expect(setInteger('a', 0.01).toString()).toBe(`$a_0`); // Round down
+  });
+
+  it('tests setString with common variable values', () => {
+    // Strings are trivially supported, so this test tests for numbers
+    expect(setString('a', -1).toString()).toBe(`$a_!-1!`);
+    expect(setString('a', 0).toString()).toBe(`$a_!0!`);
+    expect(setString('a', 1).toString()).toBe(`$a_!1!`);
+    expect(setString('a', 0.01).toString()).toBe(`$a_!0.01!`);
   });
 
   it('Creates a cloudinaryURL with number variable', () => {

--- a/src/actions/variable.ts
+++ b/src/actions/variable.ts
@@ -90,9 +90,7 @@ function setInteger(name: string, value: number): SetAction {
  * @return {Actions.Variable.SetAction}
  */
 function setString(name: string, value: string | number): SetAction {
-  const val = typeof value === 'string' ? value : value.toString();
-
-  return new SetAction(name, val);
+  return new SetAction(name, value.toString());
 }
 
 

--- a/src/actions/variable.ts
+++ b/src/actions/variable.ts
@@ -3,6 +3,7 @@ import SetAssetReferenceAction from "./variable/SetAssetReferenceAction";
 import SetFromContextAction from "./variable/SetFromContextAction";
 import SetFromMetadataAction from "./variable/SetFromMetadataAction";
 import {ExpressionQualifier} from "../qualifiers/expression/ExpressionQualifier";
+import {toFloatAsString} from "../internal/utils/toFloatAsString";
 
 /**
  * Defines a new user variable with the given value.
@@ -34,13 +35,68 @@ import {ExpressionQualifier} from "../qualifiers/expression/ExpressionQualifier"
  * @summary action
  * @description Sets a new user variable with the given value.
  * @memberOf Actions.Variable
- * @param name Variable name
+ * @param {string} name Variable name
  * @param {number | string | number[] | string[]} value Variable value
  * @return {Actions.Variable.SetAction}
  */
 function set(name: string, value: number | string | number[] | string[] | ExpressionQualifier): SetAction {
+  if (Object.prototype.hasOwnProperty.call(value, 'push')) {
+    return new SetAction(name, value);
+  }
+
   return new SetAction(name, value);
 }
+
+/**
+ * @summary action
+ * @description Same as 'set', but forces the end value to be a float  setFloat(1) will result in $foo_1.0
+ * @memberOf Actions.Variable
+ * @param {string} name Variable name
+ * @param {number} value Variable value
+ * @return {Actions.Variable.SetAction}
+ */
+function setFloat(name: string, value: number): SetAction {
+  return new SetAction(name, toFloatAsString(value), '');
+}
+
+/**
+ * @summary action
+ * @description Same as 'set', but forces the end value to be an integer setInteger(1.1) will result in $foo_1, input is rounded down
+ * @memberOf Actions.Variable
+ * @param {string} name Variable name
+ * @param {number} value Variable value
+ * @return {Actions.Variable.SetAction}
+ */
+function setInteger(name: string, value: number): SetAction {
+  let val = value;
+  if (typeof value === 'string') {
+    val = parseInt(value);
+  }
+
+  if (isNaN(val)) {
+    val = 0;
+  }
+
+  return new SetAction(name, Math.round(val));
+}
+
+
+/**
+ * @summary action
+ * @description Same as 'set', but forces the end value to be a string setString(1) will result in $foo_!1!
+ * @memberOf Actions.Variable
+ * @param {string, number} name Variable name
+ * @param {number} value Variable value
+ * @return {Actions.Variable.SetAction}
+ */
+function setString(name: string, value: string | number): SetAction {
+  const val = typeof value === 'string' ? value : value.toString();
+
+  return new SetAction(name, val);
+}
+
+
+
 
 /**
  * @summary action
@@ -82,12 +138,18 @@ function setFromMetadata(name: string, value: string): SetFromMetadataAction {
 
 const Variable = {
   set,
+  setFloat,
+  setString,
+  setInteger,
   setAssetReference,
   setFromContext,
   setFromMetadata
 };
 export {
   set,
+  setFloat,
+  setString,
+  setInteger,
   setAssetReference,
   setFromContext,
   setFromMetadata,

--- a/src/actions/variable/SetAction.ts
+++ b/src/actions/variable/SetAction.ts
@@ -9,16 +9,22 @@ import {ExpressionQualifier} from "../../qualifiers/expression/ExpressionQualifi
  * @see Visit {@link Actions.Variable|Variable} for an example
  */
 class SetAction extends VariableAction {
-  constructor(name: string, value: number | string | string[] | number[] | ExpressionQualifier) {
+  constructor(name: string, value: number | string | string[] | number[] | ExpressionQualifier, wrapper = '!') {
+    let finalValue: string | number | ExpressionQualifier;
+
     const parsedValue = Array.isArray(value) ? value.join(':') : value;
 
-
-    let finalValue: string | number | ExpressionQualifier;
     if (isString(parsedValue)) {
-      finalValue = `!${parsedValue
+      /*
+       * Encoding needed to make the Variable value Cloudinary Safe
+       * If a string, we also determine what wrapper is used (wrapper variable)
+       * The wrapper variable is needed because floats are passed as strings ('1.0') - in those case
+       * we don't need to treat them as URL strings ($foo_!1.0!), but instead as foo_1.0
+       */
+      finalValue = `${wrapper}${parsedValue
         .replace(/,/g, '%2C')
         .replace(/\//g, '%2F')
-        .replace(/!/g, '%21')}!`;
+        .replace(/!/g, '%21')}${wrapper}`;
     } else {
       finalValue = parsedValue;
     }


### PR DESCRIPTION
### Pull request for @Cloudinary/Base


#### What does this PR solve?
Add new setters to variable: float, integer and string

1. Modify setAction so that the wrapper of a string can be controlled (We needed to control the presence of the ! wrapper)
2. Add three setter methods in Variable
3. Each method performs the required parsing and passes the parsed result into the original SetAction constructor

