### PR TITLE
Add failing tests that cover more backward compatibility cases

### DIFF
--- a/__TESTS__/backwardsComaptibility/createV1URL.test.ts
+++ b/__TESTS__/backwardsComaptibility/createV1URL.test.ts
@@ -81,6 +81,23 @@ describe('Create v1 urls', () => {
     expect(url).toEqual("https://res.cloudinary.com/test123/image/upload/if_w_lt_200,c_fill,h_120,w_80/if_w_gt_400,c_fit,h_150,w_150/e_sepia/sample");
   });
 
+  it("should not modify options objects when chaining transformations ", function () {
+    const optionObj = {
+      cloud_name: 'test123',
+      transformation: [{
+        overlay: 'somepid',
+        crop: "fill",
+        height: 120,
+        width: 80
+      }]
+    };
+    const urlFirstRun = createCloudinaryV1URL("sample", optionObj);
+    const urlSecondRun = createCloudinaryV1URL("sample", optionObj);
+
+    expect(urlFirstRun).toEqual("https://res.cloudinary.com/test123/image/upload/c_fill,h_120,w_80/sample");
+    expect(urlFirstRun).toEqual(urlSecondRun);
+  });
+
   it("should translate operators", function () {
     const url = createCloudinaryV1URL("sample", {
       cloud_name: 'test123',

--- a/__TESTS__/backwardsComaptibility/generateTransformationString.test.ts
+++ b/__TESTS__/backwardsComaptibility/generateTransformationString.test.ts
@@ -136,4 +136,49 @@ describe('it works?', () => {
     const t = generateTransformationString(options);
     expect(t).toEqual("$big_$small_pow_1.5,$small_150");
   });
+
+  it("border can be presented as objects", function () {
+    const optionsAsObject = {
+      transformation: [
+        {
+          border: { width: 4, color: 'white' }
+        }
+      ]
+    };
+    const optionsAsString = {
+      transformation: [
+        {
+          border: '4px_solid_white'
+        }
+      ]
+    };
+    const tObj = generateTransformationString(optionsAsObject);
+    const tStr = generateTransformationString(optionsAsString);
+    expect(tStr).toEqual("bo_4px_solid_white");
+    expect(tStr).toEqual(tObj);
+  });
+
+  it("radius as an array is parsed", function () {
+    const options = {
+      transformation: [
+        {
+          radius: [10, 20, 30, 40]
+        }
+      ]
+    };
+    const t = generateTransformationString(options);
+    expect(t).toEqual("r_10:20:30:40");
+  });
+
+  it("radius accepts a string value", function () {
+    const options = {
+      transformation: [
+        {
+          radius: 'max'
+        }
+      ]
+    };
+    const t = generateTransformationString(options);
+    expect(t).toEqual("r_max");
+  });
 });


### PR DESCRIPTION
### Pull request for @Cloudinary/Base


#### What does this PR solve?
Highlights some backward compatibility failed-cases. (adds the test cases).

Here are the failing cases:
- "radius" does not accept a string (treats as null) or an array (crashes) - Bug is around [here](https://github.com/cloudinary/cloudinary-js-base/blob/365d9254736ef6d6c7ad0ef216a4d85ff4683401/src/backwards/transformationProcessing/processRadius.ts#L17).
- "border" should accept an object not just a string (V1 accepts an object see [here](https://github.com/cloudinary/cloudinary_js/blob/8859ceb9ab864903e820d1eef2287897808379fe/src/transformation.js#L592))
- transformation "layers" should clone before modifying "layer" options (See [here](https://github.com/cloudinary/cloudinary-js-base/blob/365d9254736ef6d6c7ad0ef216a4d85ff4683401/src/backwards/generateTransformationString.ts#L100))