### PR TITLE
Fix the path of the ruby project from which tests are built

### DIFF
--- a/scripts/updateCompliationTests.js
+++ b/scripts/updateCompliationTests.js
@@ -25,7 +25,7 @@ const addKeyEnvVar = process.env.KEY ? `KEY=${process.env.KEY}` : ''
 const bashScript = ` 
   cd ${CODE_GENERATOR_PATH};
   # NOTE - We pipe the response of rspec to prevent the script from exiting in case the rspec command fails
-  source ~/.rvm/scripts/rvm && rvm use ${ENV_RUBY_VER} && ${addKeyEnvVar} DEV_ENV=DEV rspec ${CODE_GENERATOR_PATH}  | grep 'ok'
+  source ~/.rvm/scripts/rvm && rvm use ${ENV_RUBY_VER} && ${addKeyEnvVar} DEV_ENV=DEV rspec ${CODE_GENERATOR_PATH}/spec/code_generator/manual/sanity_spec.rb  | grep 'ok'
 `;
 
 // Create the bash script


### PR DESCRIPTION
### Pull request for @Cloudinary/Base


#### What does this PR solve?
Fix the path of the ruby project from which tests are built