### PR TITLE
Fix lodash.cloneDeep import

### DIFF
--- a/__TESTS_BUNDLE_SIZE__/bundleSizeTestCases.ts
+++ b/__TESTS_BUNDLE_SIZE__/bundleSizeTestCases.ts
@@ -66,15 +66,15 @@ const bundleSizeTestCases:ITestCase[] = [
     ]
   },
   {
-    name: 'Import backwards comaptiblity function',
-    sizeLimitInKB: 57,
+    name: 'Import backwards compatibility function',
+    sizeLimitInKB: 58,
     importsArray: [
       importFromBase('createCloudinaryLegacyURL')
     ]
   },
   {
     name: 'Import all of the SDK',
-    sizeLimitInKB: 118,
+    sizeLimitInKB: 119,
     importsArray: [
       importFromBase('CloudinaryBaseSDK')
     ]

--- a/__TESTS_BUNDLE_SIZE__/bundleSizeTestCases.ts
+++ b/__TESTS_BUNDLE_SIZE__/bundleSizeTestCases.ts
@@ -67,14 +67,14 @@ const bundleSizeTestCases:ITestCase[] = [
   },
   {
     name: 'Import backwards compatibility function',
-    sizeLimitInKB: 58,
+    sizeLimitInKB: 57,
     importsArray: [
       importFromBase('createCloudinaryLegacyURL')
     ]
   },
   {
     name: 'Import all of the SDK',
-    sizeLimitInKB: 119,
+    sizeLimitInKB: 118,
     importsArray: [
       importFromBase('CloudinaryBaseSDK')
     ]

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "webpack": "^4.44.1"
   },
   "dependencies": {
-    "@types/lodash.clonedeep": "^4.5.6",
-    "lodash.clonedeep": "^4.5.0"
+    "@types/clone-deep": "^4.0.1",
+    "clone-deep": "^4.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "webpack": "^4.44.1"
   },
   "dependencies": {
-    "@types/clone-deep": "^4.0.1",
-    "clone-deep": "^4.0.1"
+    "@types/lodash.clonedeep": "^4.5.6",
+    "lodash.clonedeep": "^4.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "webpack": "^4.44.1"
   },
   "dependencies": {
-    "deep-copy": "^1.4.2"
+    "@types/clone-deep": "^4.0.1",
+    "clone-deep": "^4.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "webpack": "^4.44.1"
   },
   "dependencies": {
-    "@types/clone-deep": "^4.0.1",
-    "clone-deep": "^4.0.1"
+    "deep-copy": "^1.4.2"
   }
 }

--- a/src/assets/CloudinaryMedia.ts
+++ b/src/assets/CloudinaryMedia.ts
@@ -5,7 +5,7 @@ import {LayerAction} from "../actions/layer/LayerAction";
 import {Transformation} from "../transformation/Transformation";
 import ICloudConfig from "../config/interfaces/Config/ICloudConfig";
 import IURLConfig from "../config/interfaces/Config/IURLConfig";
-import cloneDeep from 'lodash.cloneDeep';
+import cloneDeep from 'clone-deep';
 import {ITrackedPropertiesThroughAnalytics} from "../sdkAnalytics/interfaces/ITrackedPropertiesThroughAnalytics";
 
 

--- a/src/assets/CloudinaryMedia.ts
+++ b/src/assets/CloudinaryMedia.ts
@@ -5,7 +5,7 @@ import {LayerAction} from "../actions/layer/LayerAction";
 import {Transformation} from "../transformation/Transformation";
 import ICloudConfig from "../config/interfaces/Config/ICloudConfig";
 import IURLConfig from "../config/interfaces/Config/IURLConfig";
-import cloneDeep from 'lodash/cloneDeep';
+import cloneDeep from 'lodash.cloneDeep';
 import {ITrackedPropertiesThroughAnalytics} from "../sdkAnalytics/interfaces/ITrackedPropertiesThroughAnalytics";
 
 

--- a/src/assets/CloudinaryMedia.ts
+++ b/src/assets/CloudinaryMedia.ts
@@ -5,7 +5,7 @@ import {LayerAction} from "../actions/layer/LayerAction";
 import {Transformation} from "../transformation/Transformation";
 import ICloudConfig from "../config/interfaces/Config/ICloudConfig";
 import IURLConfig from "../config/interfaces/Config/IURLConfig";
-import cloneDeep from 'clone-deep';
+import { cloneDeep } from '../internal/utils/cloneDeep';
 import {ITrackedPropertiesThroughAnalytics} from "../sdkAnalytics/interfaces/ITrackedPropertiesThroughAnalytics";
 
 

--- a/src/backwards/configuration.ts
+++ b/src/backwards/configuration.ts
@@ -1,4 +1,4 @@
-import cloneDeep from 'lodash.clonedeep';
+import cloneDeep from 'clone-deep';
 import {isObject} from "./utils/isObject";
 /**
  * Class for defining account configuration options.

--- a/src/backwards/configuration.ts
+++ b/src/backwards/configuration.ts
@@ -1,4 +1,4 @@
-import cloneDeep from 'clone-deep';
+import { cloneDeep } from '../internal/utils/cloneDeep';
 import {isObject} from "./utils/isObject";
 /**
  * Class for defining account configuration options.

--- a/src/backwards/createCloudinaryLegacyURL.ts
+++ b/src/backwards/createCloudinaryLegacyURL.ts
@@ -3,7 +3,7 @@ import {generateTransformationString} from "./generateTransformationString";
 import {finalize_resource_type} from "./utils/finalizeResourceType";
 import {finalize_source} from "./utils/finalize_source";
 import {unsigned_url_prefix} from "./utils/unsigned_url_prefix";
-import cloneDeep from 'clone-deep';
+import { cloneDeep } from '../internal/utils/cloneDeep';
 
 export function createCloudinaryLegacyURL(public_id: string, transformationOptions: LegacyITransforamtionOptions) {
   // Path format

--- a/src/backwards/createCloudinaryLegacyURL.ts
+++ b/src/backwards/createCloudinaryLegacyURL.ts
@@ -3,7 +3,7 @@ import {generateTransformationString} from "./generateTransformationString";
 import {finalize_resource_type} from "./utils/finalizeResourceType";
 import {finalize_source} from "./utils/finalize_source";
 import {unsigned_url_prefix} from "./utils/unsigned_url_prefix";
-import cloneDeep from 'lodash.cloneDeep';
+import cloneDeep from 'clone-deep';
 
 export function createCloudinaryLegacyURL(public_id: string, transformationOptions: LegacyITransforamtionOptions) {
   // Path format

--- a/src/backwards/createCloudinaryLegacyURL.ts
+++ b/src/backwards/createCloudinaryLegacyURL.ts
@@ -3,7 +3,7 @@ import {generateTransformationString} from "./generateTransformationString";
 import {finalize_resource_type} from "./utils/finalizeResourceType";
 import {finalize_source} from "./utils/finalize_source";
 import {unsigned_url_prefix} from "./utils/unsigned_url_prefix";
-import cloneDeep from 'lodash/cloneDeep';
+import cloneDeep from 'lodash.cloneDeep';
 
 export function createCloudinaryLegacyURL(public_id: string, transformationOptions: LegacyITransforamtionOptions) {
   // Path format

--- a/src/backwards/transformation.ts
+++ b/src/backwards/transformation.ts
@@ -1,7 +1,7 @@
 import Expression from './expression';
 import Condition from './condition';
 import {CONFIG_PARAMS} from './configuration';
-import cloneDeep from 'clone-deep';
+import { cloneDeep } from '../internal/utils/cloneDeep';
 
 /**
  * A list of keys used by the url() function.

--- a/src/backwards/transformation.ts
+++ b/src/backwards/transformation.ts
@@ -1,7 +1,7 @@
 import Expression from './expression';
 import Condition from './condition';
 import {CONFIG_PARAMS} from './configuration';
-import cloneDeep from 'lodash.clonedeep';
+import cloneDeep from 'clone-deep';
 
 /**
  * A list of keys used by the url() function.

--- a/src/internal/utils/cloneDeep.ts
+++ b/src/internal/utils/cloneDeep.ts
@@ -1,11 +1,11 @@
-import cd from 'clone-deep';
+import cd from 'deep-copy';
 
 /**
  * Deep clones the given value
  * @param val
  */
 function cloneDeep<T>(val: T) {
-  return cd(val, true);
+  return cd(val);
 }
 
 export {cloneDeep};

--- a/src/internal/utils/cloneDeep.ts
+++ b/src/internal/utils/cloneDeep.ts
@@ -1,5 +1,9 @@
 import cd from 'clone-deep';
 
+/**
+ * Deep clones the given value
+ * @param val
+ */
 function cloneDeep<T>(val: T) {
   return cd(val, true);
 }

--- a/src/internal/utils/cloneDeep.ts
+++ b/src/internal/utils/cloneDeep.ts
@@ -1,11 +1,11 @@
-import cd from 'clone-deep';
+import cd from 'lodash.clonedeep';
 
 /**
  * Deep clones the given value
  * @param val
  */
 function cloneDeep<T>(val: T) {
-  return cd(val, true);
+  return cd(val);
 }
 
 export {cloneDeep};

--- a/src/internal/utils/cloneDeep.ts
+++ b/src/internal/utils/cloneDeep.ts
@@ -1,0 +1,7 @@
+import cd from 'clone-deep';
+
+function cloneDeep<T>(val: T) {
+  return cd(val, true);
+}
+
+export {cloneDeep};

--- a/src/internal/utils/cloneDeep.ts
+++ b/src/internal/utils/cloneDeep.ts
@@ -1,11 +1,11 @@
-import cd from 'deep-copy';
+import cd from 'clone-deep';
 
 /**
  * Deep clones the given value
  * @param val
  */
 function cloneDeep<T>(val: T) {
-  return cd(val);
+  return cd(val, true);
 }
 
 export {cloneDeep};


### PR DESCRIPTION
This pr fixes how lodash.cloneDeep is imported:  
1. import once using import cloneDeep from 'lodash.clonedeep'
2. wrap in a function, so that lodash won't be imported directly incorrectly in other places, and make it so that replacing cloneDeep implementation won't require updating imports.